### PR TITLE
Rename plugin factory to plugin engine

### DIFF
--- a/internal/plugin/v1/plugin_test.go
+++ b/internal/plugin/v1/plugin_test.go
@@ -70,10 +70,10 @@ func TestResourcePluginCreate(t *testing.T) {
 				PluginOptions:        "",
 				PluginFactoryName:    "NewResourcePlugin",
 			}
-			f := pluginv1.NewFactory()
-			_, err := f.NewResourcePlugin(context.TODO(), config)
+			engine := pluginv1.NewEngine()
+			_, err := engine.NewResourcePlugin(context.TODO(), config)
 			require.NoError(err)
-			p, err := f.NewResourcePlugin(context.TODO(), config)
+			p, err := engine.NewResourcePlugin(context.TODO(), config)
 			require.NoError(err)
 
 			resp, err := p.CreateResource(context.TODO(), test.request)
@@ -133,10 +133,10 @@ func TestResourcePluginRead(t *testing.T) {
 				PluginOptions:        "",
 				PluginFactoryName:    "NewResourcePlugin",
 			}
-			f := pluginv1.NewFactory()
-			_, err := f.NewResourcePlugin(context.TODO(), config)
+			engine := pluginv1.NewEngine()
+			_, err := engine.NewResourcePlugin(context.TODO(), config)
 			require.NoError(err)
-			p, err := f.NewResourcePlugin(context.TODO(), config)
+			p, err := engine.NewResourcePlugin(context.TODO(), config)
 			require.NoError(err)
 
 			resp, err := p.ReadResource(context.TODO(), test.request)
@@ -196,10 +196,10 @@ func TestResourcePluginUpdate(t *testing.T) {
 				PluginOptions:        "",
 				PluginFactoryName:    "NewResourcePlugin",
 			}
-			f := pluginv1.NewFactory()
-			_, err := f.NewResourcePlugin(context.TODO(), config)
+			engine := pluginv1.NewEngine()
+			_, err := engine.NewResourcePlugin(context.TODO(), config)
 			require.NoError(err)
-			p, err := f.NewResourcePlugin(context.TODO(), config)
+			p, err := engine.NewResourcePlugin(context.TODO(), config)
 			require.NoError(err)
 
 			resp, err := p.UpdateResource(context.TODO(), test.request)
@@ -257,10 +257,10 @@ func TestResourcePluginDelete(t *testing.T) {
 				PluginOptions:        "",
 				PluginFactoryName:    "NewResourcePlugin",
 			}
-			f := pluginv1.NewFactory()
-			_, err := f.NewResourcePlugin(context.TODO(), config)
+			engine := pluginv1.NewEngine()
+			_, err := engine.NewResourcePlugin(context.TODO(), config)
 			require.NoError(err)
-			p, err := f.NewResourcePlugin(context.TODO(), config)
+			p, err := engine.NewResourcePlugin(context.TODO(), config)
 			require.NoError(err)
 
 			resp, err := p.DeleteResource(context.TODO(), test.request)
@@ -320,10 +320,10 @@ func TestDataSourcePluginRead(t *testing.T) {
 				PluginOptions:        "",
 				PluginFactoryName:    "NewDataSourcePlugin",
 			}
-			f := pluginv1.NewFactory()
-			_, err := f.NewDataSourcePlugin(context.TODO(), config)
+			engine := pluginv1.NewEngine()
+			_, err := engine.NewDataSourcePlugin(context.TODO(), config)
 			require.NoError(err)
-			p, err := f.NewDataSourcePlugin(context.TODO(), config)
+			p, err := engine.NewDataSourcePlugin(context.TODO(), config)
 			require.NoError(err)
 
 			resp, err := p.ReadDataSource(context.TODO(), test.request)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -155,12 +155,12 @@ func (p *tfProvider) Configure(ctx context.Context, req provider.ConfigureReques
 		return
 	}
 
-	v1factory := pluginv1.NewFactory()
+	pluginV1Engine := pluginv1.NewEngine()
 
 	// Load resource plugins.
 	resourcePlugins := map[string]apiv1.ResourcePlugin{}
 	for pluginID, pluginConfig := range config.ResourcePluginsV1 {
-		plugin, err := p.loadAPIV1ResourcePlugin(ctx, v1factory, pluginConfig)
+		plugin, err := p.loadAPIV1ResourcePlugin(ctx, pluginV1Engine, pluginConfig)
 		if err != nil {
 			resp.Diagnostics.AddError("Error while loading resource plugin", fmt.Sprintf("Could not load plugin resource %q due to an error: %s", pluginID, err.Error()))
 			return
@@ -171,7 +171,7 @@ func (p *tfProvider) Configure(ctx context.Context, req provider.ConfigureReques
 	// Load data source plugins.
 	dataSourcePlugins := map[string]apiv1.DataSourcePlugin{}
 	for pluginID, pluginConfig := range config.DataSourcePluginsV1 {
-		plugin, err := p.loadAPIV1DataSourcePlugin(ctx, v1factory, pluginConfig)
+		plugin, err := p.loadAPIV1DataSourcePlugin(ctx, pluginV1Engine, pluginConfig)
 		if err != nil {
 			resp.Diagnostics.AddError("Error while loading data source plugin", fmt.Sprintf("Could not load data source plugin %q due to an error: %s", pluginID, err.Error()))
 			return
@@ -196,7 +196,7 @@ func (p *tfProvider) GetDataSources(_ context.Context) (map[string]provider.Data
 	}, nil
 }
 
-func (p *tfProvider) loadAPIV1ResourcePlugin(ctx context.Context, pluginFactory *pluginv1.Factory, pluginConfig providerDataPluginV1) (apiv1.ResourcePlugin, error) {
+func (p *tfProvider) loadAPIV1ResourcePlugin(ctx context.Context, pluginFactory *pluginv1.Engine, pluginConfig providerDataPluginV1) (apiv1.ResourcePlugin, error) {
 	repo, err := p.loadAPIV1PluginSourceCode(ctx, pluginConfig.SourceCode)
 	if err != nil {
 		return nil, fmt.Errorf("error loading plugin source code: %w", err)
@@ -220,7 +220,7 @@ func (p *tfProvider) loadAPIV1ResourcePlugin(ctx context.Context, pluginFactory 
 	return plugin, nil
 }
 
-func (p *tfProvider) loadAPIV1DataSourcePlugin(ctx context.Context, pluginFactory *pluginv1.Factory, pluginConfig providerDataPluginV1) (apiv1.DataSourcePlugin, error) {
+func (p *tfProvider) loadAPIV1DataSourcePlugin(ctx context.Context, pluginFactory *pluginv1.Engine, pluginConfig providerDataPluginV1) (apiv1.DataSourcePlugin, error) {
 	repo, err := p.loadAPIV1PluginSourceCode(ctx, pluginConfig.SourceCode)
 	if err != nil {
 		return nil, fmt.Errorf("error loading plugin source code: %w", err)

--- a/pkg/api/v1/testing/testing.go
+++ b/pkg/api/v1/testing/testing.go
@@ -25,9 +25,7 @@ func NewTestResourcePlugin(ctx context.Context, pluginDir string, pluginFactoryN
 		return nil, fmt.Errorf("could not read dir %q files: %w", pluginDir, err)
 	}
 
-	f := pluginv1.NewFactory()
-
-	return f.NewResourcePlugin(ctx, pluginv1.PluginConfig{
+	return pluginv1.NewEngine().NewResourcePlugin(ctx, pluginv1.PluginConfig{
 		SourceCodeRepository: storage.StaticSourceCodeRepository(data),
 		PluginFactoryName:    pluginFactoryName,
 		PluginOptions:        configuration,
@@ -49,9 +47,7 @@ func NewTestDataSourcePlugin(ctx context.Context, pluginDir string, pluginFactor
 		return nil, fmt.Errorf("could not read dir %q files: %w", pluginDir, err)
 	}
 
-	f := pluginv1.NewFactory()
-
-	return f.NewDataSourcePlugin(ctx, pluginv1.PluginConfig{
+	return pluginv1.NewEngine().NewDataSourcePlugin(ctx, pluginv1.PluginConfig{
 		SourceCodeRepository: storage.StaticSourceCodeRepository(data),
 		PluginFactoryName:    pluginFactoryName,
 		PluginOptions:        configuration,


### PR DESCRIPTION
Also fixed the plugin cache, Now that we let users select the name of the factory inside the plugin source code, we need to use that name as plugin key also. 