### PR TITLE
Add Go package plugins and remove single data files support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           - '1.0.*'
           - '1.1.*'
           - '1.2.*'
+          - '1.3.*'
           - 'latest'
     steps:
       - uses: actions/setup-go@v3

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ rm -rf ./.terraform ./.terraform.lock.hcl
 cd -
 make install
 cd -
+terraform init
 terraform plan
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,67 +30,63 @@ terraform {
 }
 
 // Load all required plugins on the provider.
-provider goplugin { 
+provider "goplugin" {
   data_source_plugins_v1 = {
     "os_file" : {
-      source_code = {
-        data = [for f in fileset("./", "../os_file/plugins/resource_os_file/*"): file(f)]
-      }
+      source_code   = { dir = "../os_file/plugins/resource_os_file" }
       configuration = jsonencode({})
     }
   }
 
   resource_plugins_v1 = {
-    "os_file": {
-      source_code = {
-        data = [for f in fileset("./", "../os_file/plugins/resource_os_file/*"): file(f)]
-      }
-      configuration =  jsonencode({})
+    "os_file" : {
+      source_code   = { dir = "../os_file/plugins/resource_os_file" }
+      configuration = jsonencode({})
     }
 
-    "github_gist": {
+    "github_gist" : {
       source_code = {
         git = {
           url = "https://github.com/slok/terraform-provider-goplugin"
-          paths_regex = ["examples/github_gist/plugins/.*\\.go"]
-        } 
+          dir = "/examples/github_gist/plugins/resource_gist"
+        }
       }
-      configuration =  jsonencode({
-         // TF_GITHUB_TOKEN loaded from env var.
-         api_url = "https://api.github.com"
+      configuration = jsonencode({
+        // TF_GITHUB_TOKEN loaded from env var.
+        api_url = "https://api.github.com"
       })
     }
   }
 }
 
 locals {
-    files = {
-        "tf-test1.txt": "test-1"
-        "tf-test2.txt": "test-2"
-        "tf-test3.txt": "test-3"
-    }
+  files = {
+    "tf-test1.txt" : "test-1"
+    "tf-test2.txt" : "test-2"
+    "tf-test3.txt" : "test-3"
+  }
 }
 
 // Use the plugins.
 resource "goplugin_plugin_v1" "os_file_test" {
   for_each = local.files
-  
+
   plugin_id = "os_file"
   attributes = jsonencode({
-    path = "/tmp/${each.key}"
+    path    = "/tmp/${each.key}"
     content = each.value
-    mode = 644
+    mode    = 644
   })
 }
 
 resource "goplugin_plugin_v1" "github_gist_test" {
   for_each = local.files
-  
+
   plugin_id = "github_gist"
   attributes = jsonencode({
     description = "Managed by terraform."
-    public = true
-    files = {"${each.key}": each.value}
+    public      = true
+    files       = { "${each.key}" : each.value }
   })
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,14 +3,14 @@
 page_title: "goplugin Provider"
 subcategory: ""
 description: |-
-  A Terraform provider to create terraform providers 🤯, but easier and faster!
+  A Terraform provider to create terraform providers, but easier and faster!
   Terraform go plugin provider is a Terraform provider that will let you execute Go plugins (using yaegi https://github.com/traefik/yaegi) in terraform by implementing a very simple and small Go API.
   Check all full documentation on the repository readme https://github.com/slok/terraform-provider-goplugin.Check the examples https://github.com/slok/terraform-provider-goplugin/tree/main/examples to see how to develop your own plugins.Check Go v1 lib https://pkg.go.dev/github.com/slok/terraform-provider-goplugin/pkg/api/v1.
 ---
 
 # goplugin Provider
 
-A Terraform provider to create terraform providers 🤯, but easier and faster!
+A Terraform provider to create terraform providers, but easier and faster!
 
 Terraform go plugin provider is a Terraform provider that will let you execute Go plugins (using [yaegi](https://github.com/traefik/yaegi)) in terraform by implementing a very simple and small Go API.
 
@@ -133,7 +133,7 @@ Optional:
 
 Optional:
 
-- `data` (List of String) Raw content data of the plugins.
+- `dir` (String) Directory where the plugin go module root is. It will load all files including vendor directory, factories must be at the module root level, however it can have subpacakges.
 - `git` (Attributes) Git repository to get the plugin source data from. (see [below for nested schema](#nestedatt--data_source_plugins_v1--source_code--git))
 
 <a id="nestedatt--data_source_plugins_v1--source_code--git"></a>
@@ -141,12 +141,12 @@ Optional:
 
 Required:
 
-- `paths_regex` (List of String) List of regex that will match the files that will be loaded as the plugin source data.
 - `url` (String) URL of the repository.
 
 Optional:
 
 - `auth` (Attributes) Optional git authentication, if block exists it will enable (and also try loading env vars), if missing all auth will be disabled (not loading env vars). (see [below for nested schema](#nestedatt--data_source_plugins_v1--source_code--git--auth))
+- `dir` (String) Absolute directory from the root where the plugin go module is in the repository. It works the same way the `dir` source code does, supports subpackages, vendor dir...
 - `ref` (String) Reference of the the repository, only Branch and tags are supported.
 
 <a id="nestedatt--data_source_plugins_v1--source_code--git--auth"></a>
@@ -178,7 +178,7 @@ Optional:
 
 Optional:
 
-- `data` (List of String) Raw content data of the plugins.
+- `dir` (String) Directory where the plugin go module root is. It will load all files including vendor directory, factories must be at the module root level, however it can have subpacakges.
 - `git` (Attributes) Git repository to get the plugin source data from. (see [below for nested schema](#nestedatt--resource_plugins_v1--source_code--git))
 
 <a id="nestedatt--resource_plugins_v1--source_code--git"></a>
@@ -186,12 +186,12 @@ Optional:
 
 Required:
 
-- `paths_regex` (List of String) List of regex that will match the files that will be loaded as the plugin source data.
 - `url` (String) URL of the repository.
 
 Optional:
 
 - `auth` (Attributes) Optional git authentication, if block exists it will enable (and also try loading env vars), if missing all auth will be disabled (not loading env vars). (see [below for nested schema](#nestedatt--resource_plugins_v1--source_code--git--auth))
+- `dir` (String) Absolute directory from the root where the plugin go module is in the repository. It works the same way the `dir` source code does, supports subpackages, vendor dir...
 - `ref` (String) Reference of the the repository, only Branch and tags are supported.
 
 <a id="nestedatt--resource_plugins_v1--source_code--git--auth"></a>

--- a/examples/github_gist/plugins/resource_gist/go.mod
+++ b/examples/github_gist/plugins/resource_gist/go.mod
@@ -1,0 +1,1 @@
+module plugin

--- a/examples/github_gist/provider.tf
+++ b/examples/github_gist/provider.tf
@@ -1,20 +1,17 @@
 terraform {
   required_providers {
     goplugin = {
-      source = "slok/goplugin"
+      #source = "slok/goplugin"
+      source = "slok.dev/tf/goplugin"
     }
   }
 }
 
-provider goplugin { 
+provider "goplugin" {
   resource_plugins_v1 = {
-    "github_gist": {
-      source_code = {
-        data = [for f in fileset("./", "plugins/resource_gist/*"): file(f)]
-      }
-      configuration =  jsonencode({
-        // gh token loaded from `TF_GITHUB_TOKEN`
-      })
+    "github_gist" : {
+      source_code   = { dir = "plugins/resource_gist" }
+      configuration = jsonencode({}) // gh token loaded from `TF_GITHUB_TOKEN`
     }
   }
 }

--- a/examples/os_file/main.tf
+++ b/examples/os_file/main.tf
@@ -6,51 +6,47 @@ terraform {
   }
 }
 
-provider goplugin { 
+provider "goplugin" {
   resource_plugins_v1 = {
-    "os_file": {
-      source_code = {
-        data = [for f in fileset("./", "plugins/resource_os_file/*"): file(f)]
-      }
-      configuration =  jsonencode({})
+    "os_file" : {
+      source_code   = { dir = "plugins/resource_os_file" }
+      configuration = jsonencode({})
     }
   }
   data_source_plugins_v1 = {
-    "os_file": {
-      source_code = {
-        data = [for f in fileset("./", "plugins/resource_os_file/*"): file(f)]
-      }
-      configuration =  jsonencode({})
+    "os_file" : {
+      source_code   = { dir = "plugins/resource_os_file" }
+      configuration = jsonencode({})
     }
   }
 }
 
 locals {
-    files = {
-        "/tmp/tf-test1.txt": "test-1"
-        "/tmp/tf-test2.txt": "test-2"
-        "/tmp/tf-test3.txt": "test-3"
-        "/tmp/tf-test4.txt": "test-4"
-        "/tmp/tf-test5.txt": "test-5"
-        "/tmp/tf-test6.txt": "test-6"
-        "/tmp/tf-test7.txt": "test-7"
-    }
+  files = {
+    "/tmp/tf-test1.txt" : "test-1"
+    "/tmp/tf-test2.txt" : "test-2"
+    "/tmp/tf-test3.txt" : "test-3"
+    "/tmp/tf-test4.txt" : "test-4"
+    "/tmp/tf-test5.txt" : "test-5"
+    "/tmp/tf-test6.txt" : "test-6"
+    "/tmp/tf-test7.txt" : "test-7"
+  }
 }
 
 resource "goplugin_plugin_v1" "os_file_test" {
   for_each = local.files
-  
+
   plugin_id = "os_file"
   attributes = jsonencode({
-    path = each.key
+    path    = each.key
     content = each.value
-    mode = 644
+    mode    = 644
   })
 }
 
 data "goplugin_plugin_v1" "os_file_test" {
   for_each = goplugin_plugin_v1.os_file_test
-  
+
   plugin_id = "os_file"
   attributes = jsonencode({
     path = each.value.resource_id
@@ -58,5 +54,5 @@ data "goplugin_plugin_v1" "os_file_test" {
 }
 
 output "test" {
-   value = {for k, v in data.goplugin_plugin_v1.os_file_test: k => jsondecode(v.result)}
+  value = { for k, v in data.goplugin_plugin_v1.os_file_test : k => jsondecode(v.result) }
 }

--- a/examples/os_file/plugins/resource_os_file/go.mod
+++ b/examples/os_file/plugins/resource_os_file/go.mod
@@ -1,0 +1,1 @@
+module plugin

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -7,67 +7,63 @@ terraform {
 }
 
 // Load all required plugins on the provider.
-provider goplugin { 
+provider "goplugin" {
   data_source_plugins_v1 = {
     "os_file" : {
-      source_code = {
-        data = [for f in fileset("./", "../os_file/plugins/resource_os_file/*"): file(f)]
-      }
+      source_code   = { dir = "../os_file/plugins/resource_os_file" }
       configuration = jsonencode({})
     }
   }
 
   resource_plugins_v1 = {
-    "os_file": {
-      source_code = {
-        data = [for f in fileset("./", "../os_file/plugins/resource_os_file/*"): file(f)]
-      }
-      configuration =  jsonencode({})
+    "os_file" : {
+      source_code   = { dir = "../os_file/plugins/resource_os_file" }
+      configuration = jsonencode({})
     }
 
-    "github_gist": {
+    "github_gist" : {
       source_code = {
         git = {
           url = "https://github.com/slok/terraform-provider-goplugin"
-          paths_regex = ["examples/github_gist/plugins/.*\\.go"]
-        } 
+          dir = "/examples/github_gist/plugins/resource_gist"
+        }
       }
-      configuration =  jsonencode({
-         // TF_GITHUB_TOKEN loaded from env var.
-         api_url = "https://api.github.com"
+      configuration = jsonencode({
+        // TF_GITHUB_TOKEN loaded from env var.
+        api_url = "https://api.github.com"
       })
     }
   }
 }
 
 locals {
-    files = {
-        "tf-test1.txt": "test-1"
-        "tf-test2.txt": "test-2"
-        "tf-test3.txt": "test-3"
-    }
+  files = {
+    "tf-test1.txt" : "test-1"
+    "tf-test2.txt" : "test-2"
+    "tf-test3.txt" : "test-3"
+  }
 }
 
 // Use the plugins.
 resource "goplugin_plugin_v1" "os_file_test" {
   for_each = local.files
-  
+
   plugin_id = "os_file"
   attributes = jsonencode({
-    path = "/tmp/${each.key}"
+    path    = "/tmp/${each.key}"
     content = each.value
-    mode = 644
+    mode    = 644
   })
 }
 
 resource "goplugin_plugin_v1" "github_gist_test" {
   for_each = local.files
-  
+
   plugin_id = "github_gist"
   attributes = jsonencode({
     description = "Managed by terraform."
-    public = true
-    files = {"${each.key}": each.value}
+    public      = true
+    files       = { "${each.key}" : each.value }
   })
 }
 

--- a/examples/remote/main.tf
+++ b/examples/remote/main.tf
@@ -6,55 +6,55 @@ terraform {
   }
 }
 
-provider goplugin { 
+provider "goplugin" {
   resource_plugins_v1 = {
-    "os_file": {
+    "os_file" : {
       source_code = {
         git = {
           url = "https://github.com/slok/terraform-provider-goplugin"
-          paths_regex = ["examples/os_file/plugins/.*\\.go"]
-        } 
+          dir = "examples/os_file/plugins/resource_os_file"
+        }
       }
-      configuration =  jsonencode({})
+      configuration = jsonencode({})
     }
-    "github_gist": {
+    "github_gist" : {
       source_code = {
         git = {
           url = "https://github.com/slok/terraform-provider-goplugin"
-          paths_regex = ["examples/github_gist/plugins/.*\\.go"]
-        } 
+          dir = "examples/github_gist/plugins/resource_gist"
+        }
       }
-      configuration =  jsonencode({}) // TF_GITHUB_TOKEN from env var.
+      configuration = jsonencode({}) // TF_GITHUB_TOKEN from env var.
     }
   }
 }
 
 locals {
-    files = {
-        "tf-test1.txt": "test-1"
-        "tf-test2.txt": "test-2"
-        "tf-test3.txt": "test-3"
-    }
+  files = {
+    "tf-test1.txt" : "test-1"
+    "tf-test2.txt" : "test-2"
+    "tf-test3.txt" : "test-3"
+  }
 }
 
 resource "goplugin_plugin_v1" "os_file_test" {
   for_each = local.files
-  
+
   plugin_id = "os_file"
   attributes = jsonencode({
-    path = "/tmp/${each.key}"
+    path    = "/tmp/${each.key}"
     content = each.value
-    mode = 644
+    mode    = 644
   })
 }
 
 resource "goplugin_plugin_v1" "github_gist_test" {
   for_each = local.files
-  
+
   plugin_id = "github_gist"
   attributes = jsonencode({
     description = "Managed by terraform."
-    public = true
-    files = {"${each.key}": each.value}
+    public      = true
+    files       = { "${each.key}" : each.value }
   })
 }

--- a/examples/with_dependencies/main.tf
+++ b/examples/with_dependencies/main.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_providers {
+    goplugin = {
+      source = "slok/goplugin"
+    }
+  }
+}
+
+provider "goplugin" {
+  data_source_plugins_v1 = {
+    "murmur3" : {
+      source_code   = { dir = "./plugins/murmur3" }
+      configuration = jsonencode({})
+    }
+
+    "ulid" : {
+      source_code   = { dir = "./plugins/ulid" }
+      configuration = jsonencode({})
+    }
+  }
+}
+
+data "goplugin_plugin_v1" "murmur_test" {
+  plugin_id = "murmur3"
+  attributes = jsonencode({
+    value = "testing the hashes"
+  })
+}
+
+output "test_murmur" {
+  value = jsondecode(data.goplugin_plugin_v1.murmur_test.result)
+}
+
+
+data "goplugin_plugin_v1" "ulid_test" {
+  plugin_id = "ulid"
+  attributes = jsonencode({
+    value = "testing the hashes"
+  })
+}
+
+output "test_ulid" {
+  value = jsondecode(data.goplugin_plugin_v1.ulid_test.result)
+}
+

--- a/examples/with_dependencies/plugins/murmur3/go.mod
+++ b/examples/with_dependencies/plugins/murmur3/go.mod
@@ -1,0 +1,8 @@
+module murmur3
+
+go 1.19
+
+require (
+	github.com/slok/terraform-provider-goplugin v0.4.0
+	github.com/spaolacci/murmur3 v1.1.0
+)

--- a/examples/with_dependencies/plugins/murmur3/go.sum
+++ b/examples/with_dependencies/plugins/murmur3/go.sum
@@ -1,0 +1,4 @@
+github.com/slok/terraform-provider-goplugin v0.4.0 h1:6vI8Ks6RIua4Drr5rszE6Uz4TpPmwLk1eZVocprPCbw=
+github.com/slok/terraform-provider-goplugin v0.4.0/go.mod h1:pH8i9vl4gBwQ0OIYjv9NgCfIFamaSQ72Rxm8odfWuog=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/examples/with_dependencies/plugins/murmur3/murmur3.go
+++ b/examples/with_dependencies/plugins/murmur3/murmur3.go
@@ -1,0 +1,61 @@
+package murmur3
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spaolacci/murmur3"
+
+	apiv1 "github.com/slok/terraform-provider-goplugin/pkg/api/v1"
+)
+
+func NewDataSourcePlugin(config string) (apiv1.DataSourcePlugin, error) {
+	return dataSourceplugin{}, nil
+}
+
+type dataSourceplugin struct{}
+
+type tfAttributes struct {
+	Value string `json:"value"`
+}
+
+func (t tfAttributes) validate() error {
+	if t.Value == "" {
+		return fmt.Errorf("value is required")
+	}
+
+	return nil
+}
+
+type tfResult struct {
+	Hash string `json:"hash"`
+}
+
+func (d dataSourceplugin) ReadDataSource(ctx context.Context, r apiv1.ReadDataSourceRequest) (*apiv1.ReadDataSourceResponse, error) {
+	// Load input data.
+	attrs := tfAttributes{}
+	err := json.Unmarshal([]byte(r.Attributes), &attrs)
+	if err != nil {
+		return nil, err
+	}
+
+	err = attrs.validate()
+	if err != nil {
+		return nil, fmt.Errorf("invalid attributes: %w", err)
+	}
+
+	// Hash.
+	h := murmur3.Sum32([]byte(attrs.Value))
+	hashValue := strconv.Itoa(int(h))
+
+	// Output result.
+	tRes := tfResult{Hash: hashValue}
+	res, err := json.Marshal(tRes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &apiv1.ReadDataSourceResponse{Result: string(res)}, nil
+}

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/slok/terraform-provider-goplugin/LICENSE
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/slok/terraform-provider-goplugin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2022] [Xabier Larrakoetxea]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/slok/terraform-provider-goplugin/pkg/api/v1/data_source.go
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/slok/terraform-provider-goplugin/pkg/api/v1/data_source.go
@@ -1,0 +1,36 @@
+package v1
+
+import "context"
+
+// ReadDataSourceRequest is the request that the plugin will receive on resource `Read` operation.
+type ReadDataSourceRequest struct {
+	// Attributes is the data the Terraform user will provide to the plugin to manage the resource.
+	Attributes string
+}
+
+// ReadDataSourceResponse is the response that the plugin will return after resource `Read` operation.
+type ReadDataSourceResponse struct {
+	// Result is the result the plugin will return to Terraform.
+	Result string
+}
+
+// DataSourcePlugin knows how to handle a Terraform data source by implementing gathering data operations.
+type DataSourcePlugin interface {
+	// ReadDataSource will be responsible of:
+	//
+	// - Using the provided arguments to return a result.
+	ReadDataSource(ctx context.Context, r ReadDataSourceRequest) (*ReadDataSourceResponse, error)
+}
+
+// DefaultDataSourcePluginFactoryName is the default name used by the plugin engine to search for the plugin factory
+// on the plugin source code.
+const DefaultDataSourcePluginFactoryName = "NewDataSourcePlugin"
+
+// ResourcePluginFactory is the function type that the plugin engine will load and run to get the plugin that
+// will be executed afterwards. E.g:
+//
+//	func NewDataSourcePlugin(options string) (apiv1.DataSourcePlugin, error) {
+//		//...
+//		return myPlugin{}, nil
+//	}
+type DataSourcePluginFactory = func(options string) (DataSourcePlugin, error)

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/slok/terraform-provider-goplugin/pkg/api/v1/resource.go
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/slok/terraform-provider-goplugin/pkg/api/v1/resource.go
@@ -1,0 +1,99 @@
+package v1
+
+import (
+	"context"
+)
+
+// CreateResourceRequest is the request that the plugin will receive on resource `Create` operation.
+type CreateResourceRequest struct {
+	// Attributes is the data the Terraform user will provide in the configuration (tf files) to the
+	// plugin to manage the resource.
+	Attributes string
+}
+
+// CreateResourceResponse is the response that the plugin will return after resource `Create` operation.
+type CreateResourceResponse struct {
+	// ID is the ID that tracks this resource.
+	ID string
+}
+
+// ReadResourceRequest is the request that the plugin will receive on resource `Read` operation.
+type ReadResourceRequest struct {
+	// ID is the ID that tracks this resource.
+	ID string
+}
+
+// ReadResourceResponse is the response that the plugin will return after resource `Read` operation.
+type ReadResourceResponse struct {
+	// Attributes is the data the Terraform user will provide in the configuration (tf files) to the
+	// plugin to manage the resource.
+	// On read operation normally this is used to refresh the state and check the attributes provided
+	// by the user match the ones that need to be read, then Terraform will watch for drifts.
+	Attributes string
+}
+
+// UpdateResourceRequest is the request that the plugin will receive on resource `Update` operation.
+type UpdateResourceRequest struct {
+	// ID is the ID that tracks this resource.
+	ID string
+	// Attributes is the data the Terraform user will provide in the configuration (tf files) to the
+	// plugin to manage the resource.
+	Attributes string
+	// AttributesState is the same as Attributes but instead of being the configuration from the user, are
+	// the attributes used on the previous terraform apply execution.
+	//
+	// This field is meant to be used used when we want to make decisions based on previous terraform apply changes.
+	// (E.g: A resource data attribute can't be changed after the creation, so if changes we return an error)
+	AttributesState string
+}
+
+// UpdateResourceResponse is the response that the plugin will return after resource `Update` operation.
+type UpdateResourceResponse struct{}
+
+// DeleteResourceRequest is the request that the plugin will receive on resource `Delete` operation.
+type DeleteResourceRequest struct {
+	// ID is the ID that tracks this resource.
+	ID string
+}
+
+// DeleteResourceResponse is the response that the plugin will return after resource `Delete` operation.
+type DeleteResourceResponse struct{}
+
+// ResourcePlugin knows how to handle a Terraform resource by implementing the common Terraform CRUD operations.
+type ResourcePlugin interface {
+	// CreateResource will be responsible of:
+	//
+	// - Creating the resource.
+	// - Returning the correct ID that will be used from now on to identify the resource.
+	// - Generating the ID with the required information to identify a resource (e.g aggregation of 2 properties as a single ID).
+	CreateResource(ctx context.Context, r CreateResourceRequest) (*CreateResourceResponse, error)
+
+	// ReadResource will be responsible of:
+	//
+	// - Using the ID for getting the current real data of the resource (Used on plans and imports).
+	ReadResource(ctx context.Context, r ReadResourceRequest) (*ReadResourceResponse, error)
+
+	// UpdateResource will be responsible of:
+	//
+	// - Using the resource data and ID update the resource if required.
+	// - Use the latest applied resource data (state data) to get diffs if required to patch/update specific parts.
+	UpdateResource(ctx context.Context, r UpdateResourceRequest) (*UpdateResourceResponse, error)
+
+	// DeleteResource will be responsible of:
+	//
+	// - Deleting the resource using the ID.
+	DeleteResource(ctx context.Context, r DeleteResourceRequest) (*DeleteResourceResponse, error)
+}
+
+// DefaultResourcePluginFactoryName is the default name used by the plugin engine to search for the plugin factory
+// on the plugin source code.
+const DefaultResourcePluginFactoryName = "NewResourcePlugin"
+
+// ResourcePluginFactory is the function type that the plugin engine will load and run to get the plugin that
+// will be executed afterwards. E.g:
+//
+//	func NewResourcePlugin(options string) (apiv1.ResourcePlugin, error) {
+//		//...
+//		return myPlugin{}, nil
+//	}
+type ResourcePluginFactory = func(options string) (ResourcePlugin, error)

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/.gitignore
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/.travis.yml
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+    - 1.x
+    - master
+
+script: go test

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/LICENSE
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2013, Sébastien Paolacci.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the library nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/README.md
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/README.md
@@ -1,0 +1,86 @@
+murmur3
+=======
+
+[![Build Status](https://travis-ci.org/spaolacci/murmur3.svg?branch=master)](https://travis-ci.org/spaolacci/murmur3)
+
+Native Go implementation of Austin Appleby's third MurmurHash revision (aka
+MurmurHash3).
+
+Reference algorithm has been slightly hacked as to support the streaming mode
+required by Go's standard [Hash interface](http://golang.org/pkg/hash/#Hash).
+
+
+Benchmarks
+----------
+
+Go tip as of 2014-06-12 (i.e almost go1.3), core i7 @ 3.4 Ghz. All runs
+include hasher instantiation and sequence finalization.
+
+<pre>
+
+Benchmark32_1        500000000     7.69 ns/op      130.00 MB/s
+Benchmark32_2        200000000     8.83 ns/op      226.42 MB/s
+Benchmark32_4        500000000     7.99 ns/op      500.39 MB/s
+Benchmark32_8        200000000     9.47 ns/op      844.69 MB/s
+Benchmark32_16       100000000     12.1 ns/op     1321.61 MB/s
+Benchmark32_32       100000000     18.3 ns/op     1743.93 MB/s
+Benchmark32_64        50000000     30.9 ns/op     2071.64 MB/s
+Benchmark32_128       50000000     57.6 ns/op     2222.96 MB/s
+Benchmark32_256       20000000      116 ns/op     2188.60 MB/s
+Benchmark32_512       10000000      226 ns/op     2260.59 MB/s
+Benchmark32_1024       5000000      452 ns/op     2263.73 MB/s
+Benchmark32_2048       2000000      891 ns/op     2296.02 MB/s
+Benchmark32_4096       1000000     1787 ns/op     2290.92 MB/s
+Benchmark32_8192        500000     3593 ns/op     2279.68 MB/s
+Benchmark128_1       100000000     26.1 ns/op       38.33 MB/s
+Benchmark128_2       100000000     29.0 ns/op       69.07 MB/s
+Benchmark128_4        50000000     29.8 ns/op      134.17 MB/s
+Benchmark128_8        50000000     31.6 ns/op      252.86 MB/s
+Benchmark128_16      100000000     26.5 ns/op      603.42 MB/s
+Benchmark128_32      100000000     28.6 ns/op     1117.15 MB/s
+Benchmark128_64       50000000     35.5 ns/op     1800.97 MB/s
+Benchmark128_128      50000000     50.9 ns/op     2515.50 MB/s
+Benchmark128_256      20000000     76.9 ns/op     3330.11 MB/s
+Benchmark128_512      20000000      135 ns/op     3769.09 MB/s
+Benchmark128_1024     10000000      250 ns/op     4094.38 MB/s
+Benchmark128_2048      5000000      477 ns/op     4290.75 MB/s
+Benchmark128_4096      2000000      940 ns/op     4353.29 MB/s
+Benchmark128_8192      1000000     1838 ns/op     4455.47 MB/s
+
+</pre>
+
+
+<pre>
+
+benchmark              Go1.0 MB/s    Go1.1 MB/s  speedup    Go1.2 MB/s  speedup    Go1.3 MB/s  speedup
+Benchmark32_1               98.90        118.59    1.20x        114.79    0.97x        130.00    1.13x
+Benchmark32_2              168.04        213.31    1.27x        210.65    0.99x        226.42    1.07x
+Benchmark32_4              414.01        494.19    1.19x        490.29    0.99x        500.39    1.02x
+Benchmark32_8              662.19        836.09    1.26x        836.46    1.00x        844.69    1.01x
+Benchmark32_16             917.46       1304.62    1.42x       1297.63    0.99x       1321.61    1.02x
+Benchmark32_32            1141.93       1737.54    1.52x       1728.24    0.99x       1743.93    1.01x
+Benchmark32_64            1289.47       2039.51    1.58x       2038.20    1.00x       2071.64    1.02x
+Benchmark32_128           1299.23       2097.63    1.61x       2177.13    1.04x       2222.96    1.02x
+Benchmark32_256           1369.90       2202.34    1.61x       2213.15    1.00x       2188.60    0.99x
+Benchmark32_512           1399.56       2255.72    1.61x       2264.49    1.00x       2260.59    1.00x
+Benchmark32_1024          1410.90       2285.82    1.62x       2270.99    0.99x       2263.73    1.00x
+Benchmark32_2048          1422.14       2297.62    1.62x       2269.59    0.99x       2296.02    1.01x
+Benchmark32_4096          1420.53       2307.81    1.62x       2273.43    0.99x       2290.92    1.01x
+Benchmark32_8192          1424.79       2312.87    1.62x       2286.07    0.99x       2279.68    1.00x
+Benchmark128_1               8.32         30.15    3.62x         30.84    1.02x         38.33    1.24x
+Benchmark128_2              16.38         59.72    3.65x         59.37    0.99x         69.07    1.16x
+Benchmark128_4              32.26        112.96    3.50x        114.24    1.01x        134.17    1.17x
+Benchmark128_8              62.68        217.88    3.48x        218.18    1.00x        252.86    1.16x
+Benchmark128_16            128.47        451.57    3.51x        474.65    1.05x        603.42    1.27x
+Benchmark128_32            246.18        910.42    3.70x        871.06    0.96x       1117.15    1.28x
+Benchmark128_64            449.05       1477.64    3.29x       1449.24    0.98x       1800.97    1.24x
+Benchmark128_128           762.61       2222.42    2.91x       2217.30    1.00x       2515.50    1.13x
+Benchmark128_256          1179.92       3005.46    2.55x       2931.55    0.98x       3330.11    1.14x
+Benchmark128_512          1616.51       3590.75    2.22x       3592.08    1.00x       3769.09    1.05x
+Benchmark128_1024         1964.36       3979.67    2.03x       4034.01    1.01x       4094.38    1.01x
+Benchmark128_2048         2225.07       4156.93    1.87x       4244.17    1.02x       4290.75    1.01x
+Benchmark128_4096         2360.15       4299.09    1.82x       4392.35    1.02x       4353.29    0.99x
+Benchmark128_8192         2411.50       4356.84    1.81x       4480.68    1.03x       4455.47    0.99x
+
+</pre>
+

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/murmur.go
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/murmur.go
@@ -1,0 +1,64 @@
+// Copyright 2013, Sébastien Paolacci. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package murmur3 implements Austin Appleby's non-cryptographic MurmurHash3.
+
+ Reference implementation:
+    http://code.google.com/p/smhasher/wiki/MurmurHash3
+
+ History, characteristics and (legacy) perfs:
+    https://sites.google.com/site/murmurhash/
+    https://sites.google.com/site/murmurhash/statistics
+*/
+package murmur3
+
+type bmixer interface {
+	bmix(p []byte) (tail []byte)
+	Size() (n int)
+	reset()
+}
+
+type digest struct {
+	clen int      // Digested input cumulative length.
+	tail []byte   // 0 to Size()-1 bytes view of `buf'.
+	buf  [16]byte // Expected (but not required) to be Size() large.
+	seed uint32   // Seed for initializing the hash.
+	bmixer
+}
+
+func (d *digest) BlockSize() int { return 1 }
+
+func (d *digest) Write(p []byte) (n int, err error) {
+	n = len(p)
+	d.clen += n
+
+	if len(d.tail) > 0 {
+		// Stick back pending bytes.
+		nfree := d.Size() - len(d.tail) // nfree ∈ [1, d.Size()-1].
+		if nfree < len(p) {
+			// One full block can be formed.
+			block := append(d.tail, p[:nfree]...)
+			p = p[nfree:]
+			_ = d.bmix(block) // No tail.
+		} else {
+			// Tail's buf is large enough to prevent reallocs.
+			p = append(d.tail, p...)
+		}
+	}
+
+	d.tail = d.bmix(p)
+
+	// Keep own copy of the 0 to Size()-1 pending bytes.
+	nn := copy(d.buf[:], d.tail)
+	d.tail = d.buf[:nn]
+
+	return n, nil
+}
+
+func (d *digest) Reset() {
+	d.clen = 0
+	d.tail = nil
+	d.bmixer.reset()
+}

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/murmur128.go
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/murmur128.go
@@ -1,0 +1,203 @@
+package murmur3
+
+import (
+	//"encoding/binary"
+	"hash"
+	"unsafe"
+)
+
+const (
+	c1_128 = 0x87c37b91114253d5
+	c2_128 = 0x4cf5ad432745937f
+)
+
+// Make sure interfaces are correctly implemented.
+var (
+	_ hash.Hash = new(digest128)
+	_ Hash128   = new(digest128)
+	_ bmixer    = new(digest128)
+)
+
+// Hash128 represents a 128-bit hasher
+// Hack: the standard api doesn't define any Hash128 interface.
+type Hash128 interface {
+	hash.Hash
+	Sum128() (uint64, uint64)
+}
+
+// digest128 represents a partial evaluation of a 128 bites hash.
+type digest128 struct {
+	digest
+	h1 uint64 // Unfinalized running hash part 1.
+	h2 uint64 // Unfinalized running hash part 2.
+}
+
+// New128 returns a 128-bit hasher
+func New128() Hash128 { return New128WithSeed(0) }
+
+// New128WithSeed returns a 128-bit hasher set with explicit seed value
+func New128WithSeed(seed uint32) Hash128 {
+	d := new(digest128)
+	d.seed = seed
+	d.bmixer = d
+	d.Reset()
+	return d
+}
+
+func (d *digest128) Size() int { return 16 }
+
+func (d *digest128) reset() { d.h1, d.h2 = uint64(d.seed), uint64(d.seed) }
+
+func (d *digest128) Sum(b []byte) []byte {
+	h1, h2 := d.Sum128()
+	return append(b,
+		byte(h1>>56), byte(h1>>48), byte(h1>>40), byte(h1>>32),
+		byte(h1>>24), byte(h1>>16), byte(h1>>8), byte(h1),
+
+		byte(h2>>56), byte(h2>>48), byte(h2>>40), byte(h2>>32),
+		byte(h2>>24), byte(h2>>16), byte(h2>>8), byte(h2),
+	)
+}
+
+func (d *digest128) bmix(p []byte) (tail []byte) {
+	h1, h2 := d.h1, d.h2
+
+	nblocks := len(p) / 16
+	for i := 0; i < nblocks; i++ {
+		t := (*[2]uint64)(unsafe.Pointer(&p[i*16]))
+		k1, k2 := t[0], t[1]
+
+		k1 *= c1_128
+		k1 = (k1 << 31) | (k1 >> 33) // rotl64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+
+		h1 = (h1 << 27) | (h1 >> 37) // rotl64(h1, 27)
+		h1 += h2
+		h1 = h1*5 + 0x52dce729
+
+		k2 *= c2_128
+		k2 = (k2 << 33) | (k2 >> 31) // rotl64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		h2 = (h2 << 31) | (h2 >> 33) // rotl64(h2, 31)
+		h2 += h1
+		h2 = h2*5 + 0x38495ab5
+	}
+	d.h1, d.h2 = h1, h2
+	return p[nblocks*d.Size():]
+}
+
+func (d *digest128) Sum128() (h1, h2 uint64) {
+
+	h1, h2 = d.h1, d.h2
+
+	var k1, k2 uint64
+	switch len(d.tail) & 15 {
+	case 15:
+		k2 ^= uint64(d.tail[14]) << 48
+		fallthrough
+	case 14:
+		k2 ^= uint64(d.tail[13]) << 40
+		fallthrough
+	case 13:
+		k2 ^= uint64(d.tail[12]) << 32
+		fallthrough
+	case 12:
+		k2 ^= uint64(d.tail[11]) << 24
+		fallthrough
+	case 11:
+		k2 ^= uint64(d.tail[10]) << 16
+		fallthrough
+	case 10:
+		k2 ^= uint64(d.tail[9]) << 8
+		fallthrough
+	case 9:
+		k2 ^= uint64(d.tail[8]) << 0
+
+		k2 *= c2_128
+		k2 = (k2 << 33) | (k2 >> 31) // rotl64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		fallthrough
+
+	case 8:
+		k1 ^= uint64(d.tail[7]) << 56
+		fallthrough
+	case 7:
+		k1 ^= uint64(d.tail[6]) << 48
+		fallthrough
+	case 6:
+		k1 ^= uint64(d.tail[5]) << 40
+		fallthrough
+	case 5:
+		k1 ^= uint64(d.tail[4]) << 32
+		fallthrough
+	case 4:
+		k1 ^= uint64(d.tail[3]) << 24
+		fallthrough
+	case 3:
+		k1 ^= uint64(d.tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint64(d.tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint64(d.tail[0]) << 0
+		k1 *= c1_128
+		k1 = (k1 << 31) | (k1 >> 33) // rotl64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+	}
+
+	h1 ^= uint64(d.clen)
+	h2 ^= uint64(d.clen)
+
+	h1 += h2
+	h2 += h1
+
+	h1 = fmix64(h1)
+	h2 = fmix64(h2)
+
+	h1 += h2
+	h2 += h1
+
+	return h1, h2
+}
+
+func fmix64(k uint64) uint64 {
+	k ^= k >> 33
+	k *= 0xff51afd7ed558ccd
+	k ^= k >> 33
+	k *= 0xc4ceb9fe1a85ec53
+	k ^= k >> 33
+	return k
+}
+
+/*
+func rotl64(x uint64, r byte) uint64 {
+	return (x << r) | (x >> (64 - r))
+}
+*/
+
+// Sum128 returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New128()
+//     hasher.Write(data)
+//     return hasher.Sum128()
+func Sum128(data []byte) (h1 uint64, h2 uint64) { return Sum128WithSeed(data, 0) }
+
+// Sum128WithSeed returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New128WithSeed(seed)
+//     hasher.Write(data)
+//     return hasher.Sum128()
+func Sum128WithSeed(data []byte, seed uint32) (h1 uint64, h2 uint64) {
+	d := &digest128{h1: uint64(seed), h2: uint64(seed)}
+	d.seed = seed
+	d.tail = d.bmix(data)
+	d.clen = len(data)
+	return d.Sum128()
+}

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/murmur32.go
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/murmur32.go
@@ -1,0 +1,167 @@
+package murmur3
+
+// http://code.google.com/p/guava-libraries/source/browse/guava/src/com/google/common/hash/Murmur3_32HashFunction.java
+
+import (
+	"hash"
+	"unsafe"
+)
+
+// Make sure interfaces are correctly implemented.
+var (
+	_ hash.Hash   = new(digest32)
+	_ hash.Hash32 = new(digest32)
+	_ bmixer      = new(digest32)
+)
+
+const (
+	c1_32 uint32 = 0xcc9e2d51
+	c2_32 uint32 = 0x1b873593
+)
+
+// digest32 represents a partial evaluation of a 32 bites hash.
+type digest32 struct {
+	digest
+	h1 uint32 // Unfinalized running hash.
+}
+
+// New32 returns new 32-bit hasher
+func New32() hash.Hash32 { return New32WithSeed(0) }
+
+// New32WithSeed returns new 32-bit hasher set with explicit seed value
+func New32WithSeed(seed uint32) hash.Hash32 {
+	d := new(digest32)
+	d.seed = seed
+	d.bmixer = d
+	d.Reset()
+	return d
+}
+
+func (d *digest32) Size() int { return 4 }
+
+func (d *digest32) reset() { d.h1 = d.seed }
+
+func (d *digest32) Sum(b []byte) []byte {
+	h := d.Sum32()
+	return append(b, byte(h>>24), byte(h>>16), byte(h>>8), byte(h))
+}
+
+// Digest as many blocks as possible.
+func (d *digest32) bmix(p []byte) (tail []byte) {
+	h1 := d.h1
+
+	nblocks := len(p) / 4
+	for i := 0; i < nblocks; i++ {
+		k1 := *(*uint32)(unsafe.Pointer(&p[i*4]))
+
+		k1 *= c1_32
+		k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
+		k1 *= c2_32
+
+		h1 ^= k1
+		h1 = (h1 << 13) | (h1 >> 19) // rotl32(h1, 13)
+		h1 = h1*4 + h1 + 0xe6546b64
+	}
+	d.h1 = h1
+	return p[nblocks*d.Size():]
+}
+
+func (d *digest32) Sum32() (h1 uint32) {
+
+	h1 = d.h1
+
+	var k1 uint32
+	switch len(d.tail) & 3 {
+	case 3:
+		k1 ^= uint32(d.tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint32(d.tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint32(d.tail[0])
+		k1 *= c1_32
+		k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
+		k1 *= c2_32
+		h1 ^= k1
+	}
+
+	h1 ^= uint32(d.clen)
+
+	h1 ^= h1 >> 16
+	h1 *= 0x85ebca6b
+	h1 ^= h1 >> 13
+	h1 *= 0xc2b2ae35
+	h1 ^= h1 >> 16
+
+	return h1
+}
+
+/*
+func rotl32(x uint32, r byte) uint32 {
+	return (x << r) | (x >> (32 - r))
+}
+*/
+
+// Sum32 returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New32()
+//     hasher.Write(data)
+//     return hasher.Sum32()
+func Sum32(data []byte) uint32 { return Sum32WithSeed(data, 0) }
+
+// Sum32WithSeed returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New32WithSeed(seed)
+//     hasher.Write(data)
+//     return hasher.Sum32()
+func Sum32WithSeed(data []byte, seed uint32) uint32 {
+
+	h1 := seed
+
+	nblocks := len(data) / 4
+	var p uintptr
+	if len(data) > 0 {
+		p = uintptr(unsafe.Pointer(&data[0]))
+	}
+	p1 := p + uintptr(4*nblocks)
+	for ; p < p1; p += 4 {
+		k1 := *(*uint32)(unsafe.Pointer(p))
+
+		k1 *= c1_32
+		k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
+		k1 *= c2_32
+
+		h1 ^= k1
+		h1 = (h1 << 13) | (h1 >> 19) // rotl32(h1, 13)
+		h1 = h1*4 + h1 + 0xe6546b64
+	}
+
+	tail := data[nblocks*4:]
+
+	var k1 uint32
+	switch len(tail) & 3 {
+	case 3:
+		k1 ^= uint32(tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint32(tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint32(tail[0])
+		k1 *= c1_32
+		k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
+		k1 *= c2_32
+		h1 ^= k1
+	}
+
+	h1 ^= uint32(len(data))
+
+	h1 ^= h1 >> 16
+	h1 *= 0x85ebca6b
+	h1 ^= h1 >> 13
+	h1 *= 0xc2b2ae35
+	h1 ^= h1 >> 16
+
+	return h1
+}

--- a/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/murmur64.go
+++ b/examples/with_dependencies/plugins/murmur3/vendor/github.com/spaolacci/murmur3/murmur64.go
@@ -1,0 +1,57 @@
+package murmur3
+
+import (
+	"hash"
+)
+
+// Make sure interfaces are correctly implemented.
+var (
+	_ hash.Hash   = new(digest64)
+	_ hash.Hash64 = new(digest64)
+	_ bmixer      = new(digest64)
+)
+
+// digest64 is half a digest128.
+type digest64 digest128
+
+// New64 returns a 64-bit hasher
+func New64() hash.Hash64 { return New64WithSeed(0) }
+
+// New64WithSeed returns a 64-bit hasher set with explicit seed value
+func New64WithSeed(seed uint32) hash.Hash64 {
+	d := (*digest64)(New128WithSeed(seed).(*digest128))
+	return d
+}
+
+func (d *digest64) Sum(b []byte) []byte {
+	h1 := d.Sum64()
+	return append(b,
+		byte(h1>>56), byte(h1>>48), byte(h1>>40), byte(h1>>32),
+		byte(h1>>24), byte(h1>>16), byte(h1>>8), byte(h1))
+}
+
+func (d *digest64) Sum64() uint64 {
+	h1, _ := (*digest128)(d).Sum128()
+	return h1
+}
+
+// Sum64 returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New64()
+//     hasher.Write(data)
+//     return hasher.Sum64()
+func Sum64(data []byte) uint64 { return Sum64WithSeed(data, 0) }
+
+// Sum64WithSeed returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New64WithSeed(seed)
+//     hasher.Write(data)
+//     return hasher.Sum64()
+func Sum64WithSeed(data []byte, seed uint32) uint64 {
+	d := &digest128{h1: uint64(seed), h2: uint64(seed)}
+	d.seed = seed
+	d.tail = d.bmix(data)
+	d.clen = len(data)
+	h1, _ := d.Sum128()
+	return h1
+}

--- a/examples/with_dependencies/plugins/murmur3/vendor/modules.txt
+++ b/examples/with_dependencies/plugins/murmur3/vendor/modules.txt
@@ -1,0 +1,6 @@
+# github.com/slok/terraform-provider-goplugin v0.4.0
+## explicit; go 1.19
+github.com/slok/terraform-provider-goplugin/pkg/api/v1
+# github.com/spaolacci/murmur3 v1.1.0
+## explicit
+github.com/spaolacci/murmur3

--- a/examples/with_dependencies/plugins/ulid/go.mod
+++ b/examples/with_dependencies/plugins/ulid/go.mod
@@ -1,0 +1,8 @@
+module ulid
+
+go 1.19
+
+require (
+	github.com/oklog/ulid/v2 v2.1.0
+	github.com/slok/terraform-provider-goplugin v0.4.0
+)

--- a/examples/with_dependencies/plugins/ulid/go.sum
+++ b/examples/with_dependencies/plugins/ulid/go.sum
@@ -1,0 +1,5 @@
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
+github.com/slok/terraform-provider-goplugin v0.4.0 h1:6vI8Ks6RIua4Drr5rszE6Uz4TpPmwLk1eZVocprPCbw=
+github.com/slok/terraform-provider-goplugin v0.4.0/go.mod h1:pH8i9vl4gBwQ0OIYjv9NgCfIFamaSQ72Rxm8odfWuog=

--- a/examples/with_dependencies/plugins/ulid/ulid.go
+++ b/examples/with_dependencies/plugins/ulid/ulid.go
@@ -1,0 +1,42 @@
+package ulid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+
+	apiv1 "github.com/slok/terraform-provider-goplugin/pkg/api/v1"
+)
+
+func NewDataSourcePlugin(config string) (apiv1.DataSourcePlugin, error) {
+	return dataSourceplugin{}, nil
+}
+
+type dataSourceplugin struct{}
+
+type tfResult struct {
+	ULID string `json:"ulid"`
+}
+
+func (d dataSourceplugin) ReadDataSource(ctx context.Context, r apiv1.ReadDataSourceRequest) (*apiv1.ReadDataSourceResponse, error) {
+	// Hash.
+	entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
+	ms := ulid.Timestamp(time.Now())
+	ulid, err := ulid.New(ms, entropy)
+	if err != nil {
+		return nil, fmt.Errorf("could not create new ULID: %w", err)
+	}
+
+	// Output result.
+	tRes := tfResult{ULID: ulid.String()}
+	res, err := json.Marshal(tRes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &apiv1.ReadDataSourceResponse{Result: string(res)}, nil
+}

--- a/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/.gitignore
+++ b/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/.gitignore
@@ -1,0 +1,29 @@
+#### joe made this: http://goel.io/joe
+
+#####=== Go ===#####
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+

--- a/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/AUTHORS.md
+++ b/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/AUTHORS.md
@@ -1,0 +1,2 @@
+- Peter Bourgon (@peterbourgon)
+- Tomás Senart (@tsenart)

--- a/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/CHANGELOG.md
+++ b/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/CHANGELOG.md
@@ -1,0 +1,33 @@
+## 1.3.1 / 2018-10-02
+
+* Use underlying entropy source for random increments in Monotonic (#32)
+
+## 1.3.0 / 2018-09-29
+
+* Monotonic entropy support (#31)
+
+## 1.2.0 / 2018-09-09
+
+* Add a function to convert Unix time in milliseconds back to time.Time (#30)
+
+## 1.1.0 / 2018-08-15
+
+* Ensure random part is always read from the entropy reader in full (#28)
+
+## 1.0.0 / 2018-07-29
+
+* Add ParseStrict and MustParseStrict functions (#26)
+* Enforce overflow checking when parsing (#20)
+
+## 0.3.0 / 2017-01-03
+
+* Implement ULID.Compare method
+
+## 0.2.0 / 2016-12-13
+
+* Remove year 2262 Timestamp bug. (#1)
+* Gracefully handle invalid encodings when parsing.
+
+## 0.1.0 / 2016-12-06
+
+* First ULID release

--- a/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/CONTRIBUTING.md
+++ b/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+We use GitHub to manage reviews of pull requests.
+
+* If you have a trivial fix or improvement, go ahead and create a pull
+  request, addressing (with `@...`) one or more of the maintainers
+  (see [AUTHORS.md](AUTHORS.md)) in the description of the pull request.
+
+* If you plan to do something more involved, first propose your ideas
+  in a Github issue. This will avoid unnecessary work and surely give
+  you and us a good deal of inspiration.
+
+* Relevant coding style guidelines are the [Go Code Review
+  Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments)
+  and the _Formatting and style_ section of Peter Bourgon's [Go: Best
+  Practices for Production
+  Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style).

--- a/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/LICENSE
+++ b/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/README.md
+++ b/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/README.md
@@ -1,0 +1,234 @@
+# Universally Unique Lexicographically Sortable Identifier
+
+[![Project status](https://img.shields.io/github/release/oklog/ulid.svg?style=flat-square)](https://github.com/oklog/ulid/releases/latest)
+![Build Status](https://github.com/oklog/ulid/actions/workflows/test.yml/badge.svg)
+[![Go Report Card](https://goreportcard.com/badge/oklog/ulid?cache=0)](https://goreportcard.com/report/oklog/ulid)
+[![Coverage Status](https://coveralls.io/repos/github/oklog/ulid/badge.svg?branch=master&cache=0)](https://coveralls.io/github/oklog/ulid?branch=master)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/oklog/ulid/v2)
+[![Apache 2 licensed](https://img.shields.io/badge/license-Apache2-blue.svg)](https://raw.githubusercontent.com/oklog/ulid/master/LICENSE)
+
+A Go port of [ulid/javascript](https://github.com/ulid/javascript) with binary format implemented.
+
+## Background
+
+A GUID/UUID can be suboptimal for many use-cases because:
+
+- It isn't the most character efficient way of encoding 128 bits
+- UUID v1/v2 is impractical in many environments, as it requires access to a unique, stable MAC address
+- UUID v3/v5 requires a unique seed and produces randomly distributed IDs, which can cause fragmentation in many data structures
+- UUID v4 provides no other information than randomness which can cause fragmentation in many data structures
+
+A ULID however:
+
+- Is compatible with UUID/GUID's
+- 1.21e+24 unique ULIDs per millisecond (1,208,925,819,614,629,174,706,176 to be exact)
+- Lexicographically sortable
+- Canonically encoded as a 26 character string, as opposed to the 36 character UUID
+- Uses Crockford's base32 for better efficiency and readability (5 bits per character)
+- Case insensitive
+- No special characters (URL safe)
+- Monotonic sort order (correctly detects and handles the same millisecond)
+
+## Install
+
+This package requires Go modules.
+
+```shell
+go get github.com/oklog/ulid/v2
+```
+
+## Usage
+
+ULIDs are constructed from two things: a timestamp with millisecond precision,
+and some random data.
+
+Timestamps are modeled as uint64 values representing a Unix time in milliseconds.
+They can be produced by passing a [time.Time](https://pkg.go.dev/time#Time) to
+[ulid.Timestamp](https://pkg.go.dev/github.com/oklog/ulid/v2#Timestamp),
+or by calling  [time.Time.UnixMilli](https://pkg.go.dev/time#Time.UnixMilli)
+and converting the returned value to `uint64`.
+
+Random data is taken from a provided [io.Reader](https://pkg.go.dev/io#Reader).
+This design allows for greater flexibility when choosing trade-offs, but can be
+a bit confusing to newcomers.
+
+If you just want to generate a ULID and don't (yet) care about details like
+performance, cryptographic security, monotonicity, etc., use the
+[ulid.Make](https://pkg.go.dev/github.com/oklog/ulid/v2#Make) helper function.
+This function calls [time.Now](https://pkg.go.dev/time#Now) to get a timestamp,
+and uses a source of entropy which is process-global,
+[pseudo-random](https://pkg.go.dev/math/rand)), and
+[monotonic](https://pkg.go.dev/oklog/ulid/v2#LockedMonotonicReader)).
+
+```go
+println(ulid.Make())
+// 01G65Z755AFWAKHE12NY0CQ9FH
+```
+
+More advanced use cases should utilize
+[ulid.New](https://pkg.go.dev/github.com/oklog/ulid/v2#New).
+
+```go
+entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
+ms := ulid.Timestamp(time.Now())
+println(ulid.New(ms, entropy))
+// 01G65Z755AFWAKHE12NY0CQ9FH
+```
+
+Care should be taken when providing a source of entropy.
+
+The above example utilizes [math/rand.Rand](https://pkg.go.dev/math/rand#Rand),
+which is not safe for concurrent use by multiple goroutines. Consider
+alternatives such as
+[x/exp/rand](https://pkg.go.dev/golang.org/x/exp/rand#LockedSource).
+Security-sensitive use cases should always use cryptographically secure entropy
+provided by [crypto/rand](https://pkg.go.dev/crypto/rand).
+
+Performance-sensitive use cases should avoid synchronization when generating
+IDs. One option is to use a unique source of entropy for each concurrent
+goroutine, which results in no lock contention, but cannot provide strong
+guarantees about the random data, and does not provide monotonicity within a
+given millisecond. One common performance optimization is to pool sources of
+entropy using a [sync.Pool](https://pkg.go.dev/sync#Pool).
+
+Monotonicity is a property that says each ULID is "bigger than" the previous
+one. ULIDs are automatically monotonic, but only to millisecond precision. ULIDs
+generated within the same millisecond are ordered by their random component,
+which means they are by default un-ordered. You can use
+[ulid.MonotonicEntropy](https://pkg.go.dev/oklog/ulid/v2#MonotonicEntropy) or
+[ulid.LockedMonotonicEntropy](https://pkg.go.dev/oklog/ulid/v2#LockedMonotonicEntropy)
+to create ULIDs that are monotonic within a given millisecond, with caveats. See
+the documentation for details.
+
+If you don't care about time-based ordering of generated IDs, then there's no
+reason to use ULIDs! There are many other kinds of IDs that are easier, faster,
+smaller, etc. Consider UUIDs.
+
+## Commandline tool
+
+This repo also provides a tool to generate and parse ULIDs at the command line.
+These commands should install the latest version of the tool at `bin/ulid`:
+
+```shell
+cd $(mktemp -d)
+env GOPATH=$(pwd) GO111MODULE=on go get -v github.com/oklog/ulid/v2/cmd/ulid
+```
+
+Usage:
+
+```shell
+Usage: ulid [-hlqz] [-f <format>] [parameters ...]
+ -f, --format=<format>  when parsing, show times in this format: default, rfc3339, unix, ms
+ -h, --help             print this help text
+ -l, --local            when parsing, show local time instead of UTC
+ -q, --quick            when generating, use non-crypto-grade entropy
+ -z, --zero             when generating, fix entropy to all-zeroes
+```
+
+Examples:
+
+```shell
+$ ulid
+01D78XYFJ1PRM1WPBCBT3VHMNV
+$ ulid -z
+01D78XZ44G0000000000000000
+$ ulid 01D78XZ44G0000000000000000
+Sun Mar 31 03:51:23.536 UTC 2019
+$ ulid --format=rfc3339 --local 01D78XZ44G0000000000000000
+2019-03-31T05:51:23.536+02:00
+```
+
+## Specification
+
+Below is the current specification of ULID as implemented in this repository.
+
+### Components
+
+**Timestamp**
+- 48 bits
+- UNIX-time in milliseconds
+- Won't run out of space till the year 10889 AD
+
+**Entropy**
+- 80 bits
+- User defined entropy source.
+- Monotonicity within the same millisecond with [`ulid.Monotonic`](https://godoc.org/github.com/oklog/ulid#Monotonic)
+
+### Encoding
+
+[Crockford's Base32](http://www.crockford.com/wrmg/base32.html) is used as shown.
+This alphabet excludes the letters I, L, O, and U to avoid confusion and abuse.
+
+```
+0123456789ABCDEFGHJKMNPQRSTVWXYZ
+```
+
+### Binary Layout and Byte Order
+
+The components are encoded as 16 octets. Each component is encoded with the Most Significant Byte first (network byte order).
+
+```
+0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      32_bit_uint_time_high                    |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|     16_bit_uint_time_low      |       16_bit_uint_random      |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       32_bit_uint_random                      |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       32_bit_uint_random                      |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
+### String Representation
+
+```
+ 01AN4Z07BY      79KA1307SR9X4MV3
+|----------|    |----------------|
+ Timestamp           Entropy
+  10 chars           16 chars
+   48bits             80bits
+   base32             base32
+```
+
+## Test
+
+```shell
+go test ./...
+```
+
+## Benchmarks
+
+On a Intel Core i7 Ivy Bridge 2.7 GHz, MacOS 10.12.1 and Go 1.8.0beta1
+
+```
+BenchmarkNew/WithCryptoEntropy-8      2000000        771 ns/op      20.73 MB/s   16 B/op   1 allocs/op
+BenchmarkNew/WithEntropy-8            20000000      65.8 ns/op     243.01 MB/s   16 B/op   1 allocs/op
+BenchmarkNew/WithoutEntropy-8         50000000      30.0 ns/op     534.06 MB/s   16 B/op   1 allocs/op
+BenchmarkMustNew/WithCryptoEntropy-8  2000000        781 ns/op      20.48 MB/s   16 B/op   1 allocs/op
+BenchmarkMustNew/WithEntropy-8        20000000      70.0 ns/op     228.51 MB/s   16 B/op   1 allocs/op
+BenchmarkMustNew/WithoutEntropy-8     50000000      34.6 ns/op     462.98 MB/s   16 B/op   1 allocs/op
+BenchmarkParse-8                      50000000      30.0 ns/op     866.16 MB/s    0 B/op   0 allocs/op
+BenchmarkMustParse-8                  50000000      35.2 ns/op     738.94 MB/s    0 B/op   0 allocs/op
+BenchmarkString-8                     20000000      64.9 ns/op     246.40 MB/s   32 B/op   1 allocs/op
+BenchmarkMarshal/Text-8               20000000      55.8 ns/op     286.84 MB/s   32 B/op   1 allocs/op
+BenchmarkMarshal/TextTo-8             100000000     22.4 ns/op     714.91 MB/s    0 B/op   0 allocs/op
+BenchmarkMarshal/Binary-8             300000000     4.02 ns/op    3981.77 MB/s    0 B/op   0 allocs/op
+BenchmarkMarshal/BinaryTo-8           2000000000    1.18 ns/op   13551.75 MB/s    0 B/op   0 allocs/op
+BenchmarkUnmarshal/Text-8             100000000     20.5 ns/op    1265.27 MB/s    0 B/op   0 allocs/op
+BenchmarkUnmarshal/Binary-8           300000000     4.94 ns/op    3240.01 MB/s    0 B/op   0 allocs/op
+BenchmarkNow-8                        100000000     15.1 ns/op     528.09 MB/s    0 B/op   0 allocs/op
+BenchmarkTimestamp-8                  2000000000    0.29 ns/op   27271.59 MB/s    0 B/op   0 allocs/op
+BenchmarkTime-8                       2000000000    0.58 ns/op   13717.80 MB/s    0 B/op   0 allocs/op
+BenchmarkSetTime-8                    2000000000    0.89 ns/op    9023.95 MB/s    0 B/op   0 allocs/op
+BenchmarkEntropy-8                    200000000     7.62 ns/op    1311.66 MB/s    0 B/op   0 allocs/op
+BenchmarkSetEntropy-8                 2000000000    0.88 ns/op   11376.54 MB/s    0 B/op   0 allocs/op
+BenchmarkCompare-8                    200000000     7.34 ns/op    4359.23 MB/s    0 B/op   0 allocs/op
+```
+
+## Prior Art
+
+- [ulid/javascript](https://github.com/ulid/javascript)
+- [RobThree/NUlid](https://github.com/RobThree/NUlid)
+- [imdario/go-ulid](https://github.com/imdario/go-ulid)

--- a/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/ulid.go
+++ b/examples/with_dependencies/plugins/ulid/vendor/github.com/oklog/ulid/v2/ulid.go
@@ -1,0 +1,696 @@
+// Copyright 2016 The Oklog Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ulid
+
+import (
+	"bufio"
+	"bytes"
+	"database/sql/driver"
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"math/bits"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+/*
+An ULID is a 16 byte Universally Unique Lexicographically Sortable Identifier
+
+	The components are encoded as 16 octets.
+	Each component is encoded with the MSB first (network byte order).
+
+	0                   1                   2                   3
+	0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	|                      32_bit_uint_time_high                    |
+	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	|     16_bit_uint_time_low      |       16_bit_uint_random      |
+	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	|                       32_bit_uint_random                      |
+	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	|                       32_bit_uint_random                      |
+	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+*/
+type ULID [16]byte
+
+var (
+	// ErrDataSize is returned when parsing or unmarshaling ULIDs with the wrong
+	// data size.
+	ErrDataSize = errors.New("ulid: bad data size when unmarshaling")
+
+	// ErrInvalidCharacters is returned when parsing or unmarshaling ULIDs with
+	// invalid Base32 encodings.
+	ErrInvalidCharacters = errors.New("ulid: bad data characters when unmarshaling")
+
+	// ErrBufferSize is returned when marshalling ULIDs to a buffer of insufficient
+	// size.
+	ErrBufferSize = errors.New("ulid: bad buffer size when marshaling")
+
+	// ErrBigTime is returned when constructing an ULID with a time that is larger
+	// than MaxTime.
+	ErrBigTime = errors.New("ulid: time too big")
+
+	// ErrOverflow is returned when unmarshaling a ULID whose first character is
+	// larger than 7, thereby exceeding the valid bit depth of 128.
+	ErrOverflow = errors.New("ulid: overflow when unmarshaling")
+
+	// ErrMonotonicOverflow is returned by a Monotonic entropy source when
+	// incrementing the previous ULID's entropy bytes would result in overflow.
+	ErrMonotonicOverflow = errors.New("ulid: monotonic entropy overflow")
+
+	// ErrScanValue is returned when the value passed to scan cannot be unmarshaled
+	// into the ULID.
+	ErrScanValue = errors.New("ulid: source value must be a string or byte slice")
+)
+
+// MonotonicReader is an interface that should yield monotonically increasing
+// entropy into the provided slice for all calls with the same ms parameter. If
+// a MonotonicReader is provided to the New constructor, its MonotonicRead
+// method will be used instead of Read.
+type MonotonicReader interface {
+	io.Reader
+	MonotonicRead(ms uint64, p []byte) error
+}
+
+// New returns an ULID with the given Unix milliseconds timestamp and an
+// optional entropy source. Use the Timestamp function to convert
+// a time.Time to Unix milliseconds.
+//
+// ErrBigTime is returned when passing a timestamp bigger than MaxTime.
+// Reading from the entropy source may also return an error.
+//
+// Safety for concurrent use is only dependent on the safety of the
+// entropy source.
+func New(ms uint64, entropy io.Reader) (id ULID, err error) {
+	if err = id.SetTime(ms); err != nil {
+		return id, err
+	}
+
+	switch e := entropy.(type) {
+	case nil:
+		return id, err
+	case MonotonicReader:
+		err = e.MonotonicRead(ms, id[6:])
+	default:
+		_, err = io.ReadFull(e, id[6:])
+	}
+
+	return id, err
+}
+
+// MustNew is a convenience function equivalent to New that panics on failure
+// instead of returning an error.
+func MustNew(ms uint64, entropy io.Reader) ULID {
+	id, err := New(ms, entropy)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+var (
+	entropy     io.Reader
+	entropyOnce sync.Once
+)
+
+// DefaultEntropy returns a thread-safe per process monotonically increasing
+// entropy source.
+func DefaultEntropy() io.Reader {
+	entropyOnce.Do(func() {
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+		entropy = &LockedMonotonicReader{
+			MonotonicReader: Monotonic(rng, 0),
+		}
+	})
+	return entropy
+}
+
+// Make returns an ULID with the current time in Unix milliseconds and
+// monotonically increasing entropy for the same millisecond.
+// It is safe for concurrent use, leveraging a sync.Pool underneath for minimal
+// contention.
+func Make() (id ULID) {
+	// NOTE: MustNew can't panic since DefaultEntropy never returns an error.
+	return MustNew(Now(), DefaultEntropy())
+}
+
+// Parse parses an encoded ULID, returning an error in case of failure.
+//
+// ErrDataSize is returned if the len(ulid) is different from an encoded
+// ULID's length. Invalid encodings produce undefined ULIDs. For a version that
+// returns an error instead, see ParseStrict.
+func Parse(ulid string) (id ULID, err error) {
+	return id, parse([]byte(ulid), false, &id)
+}
+
+// ParseStrict parses an encoded ULID, returning an error in case of failure.
+//
+// It is like Parse, but additionally validates that the parsed ULID consists
+// only of valid base32 characters. It is slightly slower than Parse.
+//
+// ErrDataSize is returned if the len(ulid) is different from an encoded
+// ULID's length. Invalid encodings return ErrInvalidCharacters.
+func ParseStrict(ulid string) (id ULID, err error) {
+	return id, parse([]byte(ulid), true, &id)
+}
+
+func parse(v []byte, strict bool, id *ULID) error {
+	// Check if a base32 encoded ULID is the right length.
+	if len(v) != EncodedSize {
+		return ErrDataSize
+	}
+
+	// Check if all the characters in a base32 encoded ULID are part of the
+	// expected base32 character set.
+	if strict &&
+		(dec[v[0]] == 0xFF ||
+			dec[v[1]] == 0xFF ||
+			dec[v[2]] == 0xFF ||
+			dec[v[3]] == 0xFF ||
+			dec[v[4]] == 0xFF ||
+			dec[v[5]] == 0xFF ||
+			dec[v[6]] == 0xFF ||
+			dec[v[7]] == 0xFF ||
+			dec[v[8]] == 0xFF ||
+			dec[v[9]] == 0xFF ||
+			dec[v[10]] == 0xFF ||
+			dec[v[11]] == 0xFF ||
+			dec[v[12]] == 0xFF ||
+			dec[v[13]] == 0xFF ||
+			dec[v[14]] == 0xFF ||
+			dec[v[15]] == 0xFF ||
+			dec[v[16]] == 0xFF ||
+			dec[v[17]] == 0xFF ||
+			dec[v[18]] == 0xFF ||
+			dec[v[19]] == 0xFF ||
+			dec[v[20]] == 0xFF ||
+			dec[v[21]] == 0xFF ||
+			dec[v[22]] == 0xFF ||
+			dec[v[23]] == 0xFF ||
+			dec[v[24]] == 0xFF ||
+			dec[v[25]] == 0xFF) {
+		return ErrInvalidCharacters
+	}
+
+	// Check if the first character in a base32 encoded ULID will overflow. This
+	// happens because the base32 representation encodes 130 bits, while the
+	// ULID is only 128 bits.
+	//
+	// See https://github.com/oklog/ulid/issues/9 for details.
+	if v[0] > '7' {
+		return ErrOverflow
+	}
+
+	// Use an optimized unrolled loop (from https://github.com/RobThree/NUlid)
+	// to decode a base32 ULID.
+
+	// 6 bytes timestamp (48 bits)
+	(*id)[0] = (dec[v[0]] << 5) | dec[v[1]]
+	(*id)[1] = (dec[v[2]] << 3) | (dec[v[3]] >> 2)
+	(*id)[2] = (dec[v[3]] << 6) | (dec[v[4]] << 1) | (dec[v[5]] >> 4)
+	(*id)[3] = (dec[v[5]] << 4) | (dec[v[6]] >> 1)
+	(*id)[4] = (dec[v[6]] << 7) | (dec[v[7]] << 2) | (dec[v[8]] >> 3)
+	(*id)[5] = (dec[v[8]] << 5) | dec[v[9]]
+
+	// 10 bytes of entropy (80 bits)
+	(*id)[6] = (dec[v[10]] << 3) | (dec[v[11]] >> 2)
+	(*id)[7] = (dec[v[11]] << 6) | (dec[v[12]] << 1) | (dec[v[13]] >> 4)
+	(*id)[8] = (dec[v[13]] << 4) | (dec[v[14]] >> 1)
+	(*id)[9] = (dec[v[14]] << 7) | (dec[v[15]] << 2) | (dec[v[16]] >> 3)
+	(*id)[10] = (dec[v[16]] << 5) | dec[v[17]]
+	(*id)[11] = (dec[v[18]] << 3) | dec[v[19]]>>2
+	(*id)[12] = (dec[v[19]] << 6) | (dec[v[20]] << 1) | (dec[v[21]] >> 4)
+	(*id)[13] = (dec[v[21]] << 4) | (dec[v[22]] >> 1)
+	(*id)[14] = (dec[v[22]] << 7) | (dec[v[23]] << 2) | (dec[v[24]] >> 3)
+	(*id)[15] = (dec[v[24]] << 5) | dec[v[25]]
+
+	return nil
+}
+
+// MustParse is a convenience function equivalent to Parse that panics on failure
+// instead of returning an error.
+func MustParse(ulid string) ULID {
+	id, err := Parse(ulid)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+// MustParseStrict is a convenience function equivalent to ParseStrict that
+// panics on failure instead of returning an error.
+func MustParseStrict(ulid string) ULID {
+	id, err := ParseStrict(ulid)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+// Bytes returns bytes slice representation of ULID.
+func (id ULID) Bytes() []byte {
+	return id[:]
+}
+
+// String returns a lexicographically sortable string encoded ULID
+// (26 characters, non-standard base 32) e.g. 01AN4Z07BY79KA1307SR9X4MV3.
+// Format: tttttttttteeeeeeeeeeeeeeee where t is time and e is entropy.
+func (id ULID) String() string {
+	ulid := make([]byte, EncodedSize)
+	_ = id.MarshalTextTo(ulid)
+	return string(ulid)
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface by
+// returning the ULID as a byte slice.
+func (id ULID) MarshalBinary() ([]byte, error) {
+	ulid := make([]byte, len(id))
+	return ulid, id.MarshalBinaryTo(ulid)
+}
+
+// MarshalBinaryTo writes the binary encoding of the ULID to the given buffer.
+// ErrBufferSize is returned when the len(dst) != 16.
+func (id ULID) MarshalBinaryTo(dst []byte) error {
+	if len(dst) != len(id) {
+		return ErrBufferSize
+	}
+
+	copy(dst, id[:])
+	return nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface by
+// copying the passed data and converting it to an ULID. ErrDataSize is
+// returned if the data length is different from ULID length.
+func (id *ULID) UnmarshalBinary(data []byte) error {
+	if len(data) != len(*id) {
+		return ErrDataSize
+	}
+
+	copy((*id)[:], data)
+	return nil
+}
+
+// Encoding is the base 32 encoding alphabet used in ULID strings.
+const Encoding = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// MarshalText implements the encoding.TextMarshaler interface by
+// returning the string encoded ULID.
+func (id ULID) MarshalText() ([]byte, error) {
+	ulid := make([]byte, EncodedSize)
+	return ulid, id.MarshalTextTo(ulid)
+}
+
+// MarshalTextTo writes the ULID as a string to the given buffer.
+// ErrBufferSize is returned when the len(dst) != 26.
+func (id ULID) MarshalTextTo(dst []byte) error {
+	// Optimized unrolled loop ahead.
+	// From https://github.com/RobThree/NUlid
+
+	if len(dst) != EncodedSize {
+		return ErrBufferSize
+	}
+
+	// 10 byte timestamp
+	dst[0] = Encoding[(id[0]&224)>>5]
+	dst[1] = Encoding[id[0]&31]
+	dst[2] = Encoding[(id[1]&248)>>3]
+	dst[3] = Encoding[((id[1]&7)<<2)|((id[2]&192)>>6)]
+	dst[4] = Encoding[(id[2]&62)>>1]
+	dst[5] = Encoding[((id[2]&1)<<4)|((id[3]&240)>>4)]
+	dst[6] = Encoding[((id[3]&15)<<1)|((id[4]&128)>>7)]
+	dst[7] = Encoding[(id[4]&124)>>2]
+	dst[8] = Encoding[((id[4]&3)<<3)|((id[5]&224)>>5)]
+	dst[9] = Encoding[id[5]&31]
+
+	// 16 bytes of entropy
+	dst[10] = Encoding[(id[6]&248)>>3]
+	dst[11] = Encoding[((id[6]&7)<<2)|((id[7]&192)>>6)]
+	dst[12] = Encoding[(id[7]&62)>>1]
+	dst[13] = Encoding[((id[7]&1)<<4)|((id[8]&240)>>4)]
+	dst[14] = Encoding[((id[8]&15)<<1)|((id[9]&128)>>7)]
+	dst[15] = Encoding[(id[9]&124)>>2]
+	dst[16] = Encoding[((id[9]&3)<<3)|((id[10]&224)>>5)]
+	dst[17] = Encoding[id[10]&31]
+	dst[18] = Encoding[(id[11]&248)>>3]
+	dst[19] = Encoding[((id[11]&7)<<2)|((id[12]&192)>>6)]
+	dst[20] = Encoding[(id[12]&62)>>1]
+	dst[21] = Encoding[((id[12]&1)<<4)|((id[13]&240)>>4)]
+	dst[22] = Encoding[((id[13]&15)<<1)|((id[14]&128)>>7)]
+	dst[23] = Encoding[(id[14]&124)>>2]
+	dst[24] = Encoding[((id[14]&3)<<3)|((id[15]&224)>>5)]
+	dst[25] = Encoding[id[15]&31]
+
+	return nil
+}
+
+// Byte to index table for O(1) lookups when unmarshaling.
+// We use 0xFF as sentinel value for invalid indexes.
+var dec = [...]byte{
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x01,
+	0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
+	0x0F, 0x10, 0x11, 0xFF, 0x12, 0x13, 0xFF, 0x14, 0x15, 0xFF,
+	0x16, 0x17, 0x18, 0x19, 0x1A, 0xFF, 0x1B, 0x1C, 0x1D, 0x1E,
+	0x1F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0A, 0x0B, 0x0C,
+	0x0D, 0x0E, 0x0F, 0x10, 0x11, 0xFF, 0x12, 0x13, 0xFF, 0x14,
+	0x15, 0xFF, 0x16, 0x17, 0x18, 0x19, 0x1A, 0xFF, 0x1B, 0x1C,
+	0x1D, 0x1E, 0x1F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+}
+
+// EncodedSize is the length of a text encoded ULID.
+const EncodedSize = 26
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface by
+// parsing the data as string encoded ULID.
+//
+// ErrDataSize is returned if the len(v) is different from an encoded
+// ULID's length. Invalid encodings produce undefined ULIDs.
+func (id *ULID) UnmarshalText(v []byte) error {
+	return parse(v, false, id)
+}
+
+// Time returns the Unix time in milliseconds encoded in the ULID.
+// Use the top level Time function to convert the returned value to
+// a time.Time.
+func (id ULID) Time() uint64 {
+	return uint64(id[5]) | uint64(id[4])<<8 |
+		uint64(id[3])<<16 | uint64(id[2])<<24 |
+		uint64(id[1])<<32 | uint64(id[0])<<40
+}
+
+// maxTime is the maximum Unix time in milliseconds that can be
+// represented in an ULID.
+var maxTime = ULID{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}.Time()
+
+// MaxTime returns the maximum Unix time in milliseconds that
+// can be encoded in an ULID.
+func MaxTime() uint64 { return maxTime }
+
+// Now is a convenience function that returns the current
+// UTC time in Unix milliseconds. Equivalent to:
+//   Timestamp(time.Now().UTC())
+func Now() uint64 { return Timestamp(time.Now().UTC()) }
+
+// Timestamp converts a time.Time to Unix milliseconds.
+//
+// Because of the way ULID stores time, times from the year
+// 10889 produces undefined results.
+func Timestamp(t time.Time) uint64 {
+	return uint64(t.Unix())*1000 +
+		uint64(t.Nanosecond()/int(time.Millisecond))
+}
+
+// Time converts Unix milliseconds in the format
+// returned by the Timestamp function to a time.Time.
+func Time(ms uint64) time.Time {
+	s := int64(ms / 1e3)
+	ns := int64((ms % 1e3) * 1e6)
+	return time.Unix(s, ns)
+}
+
+// SetTime sets the time component of the ULID to the given Unix time
+// in milliseconds.
+func (id *ULID) SetTime(ms uint64) error {
+	if ms > maxTime {
+		return ErrBigTime
+	}
+
+	(*id)[0] = byte(ms >> 40)
+	(*id)[1] = byte(ms >> 32)
+	(*id)[2] = byte(ms >> 24)
+	(*id)[3] = byte(ms >> 16)
+	(*id)[4] = byte(ms >> 8)
+	(*id)[5] = byte(ms)
+
+	return nil
+}
+
+// Entropy returns the entropy from the ULID.
+func (id ULID) Entropy() []byte {
+	e := make([]byte, 10)
+	copy(e, id[6:])
+	return e
+}
+
+// SetEntropy sets the ULID entropy to the passed byte slice.
+// ErrDataSize is returned if len(e) != 10.
+func (id *ULID) SetEntropy(e []byte) error {
+	if len(e) != 10 {
+		return ErrDataSize
+	}
+
+	copy((*id)[6:], e)
+	return nil
+}
+
+// Compare returns an integer comparing id and other lexicographically.
+// The result will be 0 if id==other, -1 if id < other, and +1 if id > other.
+func (id ULID) Compare(other ULID) int {
+	return bytes.Compare(id[:], other[:])
+}
+
+// Scan implements the sql.Scanner interface. It supports scanning
+// a string or byte slice.
+func (id *ULID) Scan(src interface{}) error {
+	switch x := src.(type) {
+	case nil:
+		return nil
+	case string:
+		return id.UnmarshalText([]byte(x))
+	case []byte:
+		return id.UnmarshalBinary(x)
+	}
+
+	return ErrScanValue
+}
+
+// Value implements the sql/driver.Valuer interface, returning the ULID as a
+// slice of bytes, by invoking MarshalBinary. If your use case requires a string
+// representation instead, you can create a wrapper type that calls String()
+// instead.
+//
+//    type stringValuer ulid.ULID
+//
+//    func (v stringValuer) Value() (driver.Value, error) {
+//        return ulid.ULID(v).String(), nil
+//    }
+//
+//    // Example usage.
+//    db.Exec("...", stringValuer(id))
+//
+// All valid ULIDs, including zero-value ULIDs, return a valid Value with a nil
+// error. If your use case requires zero-value ULIDs to return a non-nil error,
+// you can create a wrapper type that special-cases this behavior.
+//
+//    var zeroValueULID ulid.ULID
+//
+//    type invalidZeroValuer ulid.ULID
+//
+//    func (v invalidZeroValuer) Value() (driver.Value, error) {
+//        if ulid.ULID(v).Compare(zeroValueULID) == 0 {
+//            return nil, fmt.Errorf("zero value")
+//        }
+//        return ulid.ULID(v).Value()
+//    }
+//
+//    // Example usage.
+//    db.Exec("...", invalidZeroValuer(id))
+//
+func (id ULID) Value() (driver.Value, error) {
+	return id.MarshalBinary()
+}
+
+// Monotonic returns an entropy source that is guaranteed to yield
+// strictly increasing entropy bytes for the same ULID timestamp.
+// On conflicts, the previous ULID entropy is incremented with a
+// random number between 1 and `inc` (inclusive).
+//
+// The provided entropy source must actually yield random bytes or else
+// monotonic reads are not guaranteed to terminate, since there isn't
+// enough randomness to compute an increment number.
+//
+// When `inc == 0`, it'll be set to a secure default of `math.MaxUint32`.
+// The lower the value of `inc`, the easier the next ULID within the
+// same millisecond is to guess. If your code depends on ULIDs having
+// secure entropy bytes, then don't go under this default unless you know
+// what you're doing.
+//
+// The returned type isn't safe for concurrent use.
+func Monotonic(entropy io.Reader, inc uint64) *MonotonicEntropy {
+	m := MonotonicEntropy{
+		Reader: bufio.NewReader(entropy),
+		inc:    inc,
+	}
+
+	if m.inc == 0 {
+		m.inc = math.MaxUint32
+	}
+
+	if rng, ok := entropy.(rng); ok {
+		m.rng = rng
+	}
+
+	return &m
+}
+
+type rng interface{ Int63n(n int64) int64 }
+
+// LockedMonotonicReader wraps a MonotonicReader with a sync.Mutex for
+// safe concurrent use.
+type LockedMonotonicReader struct {
+	mu sync.Mutex
+	MonotonicReader
+}
+
+// MonotonicRead synchronizes calls to the wrapped MonotonicReader.
+func (r *LockedMonotonicReader) MonotonicRead(ms uint64, p []byte) (err error) {
+	r.mu.Lock()
+	err = r.MonotonicReader.MonotonicRead(ms, p)
+	r.mu.Unlock()
+	return err
+}
+
+// MonotonicEntropy is an opaque type that provides monotonic entropy.
+type MonotonicEntropy struct {
+	io.Reader
+	ms      uint64
+	inc     uint64
+	entropy uint80
+	rand    [8]byte
+	rng     rng
+}
+
+// MonotonicRead implements the MonotonicReader interface.
+func (m *MonotonicEntropy) MonotonicRead(ms uint64, entropy []byte) (err error) {
+	if !m.entropy.IsZero() && m.ms == ms {
+		err = m.increment()
+		m.entropy.AppendTo(entropy)
+	} else if _, err = io.ReadFull(m.Reader, entropy); err == nil {
+		m.ms = ms
+		m.entropy.SetBytes(entropy)
+	}
+	return err
+}
+
+// increment the previous entropy number with a random number
+// of up to m.inc (inclusive).
+func (m *MonotonicEntropy) increment() error {
+	if inc, err := m.random(); err != nil {
+		return err
+	} else if m.entropy.Add(inc) {
+		return ErrMonotonicOverflow
+	}
+	return nil
+}
+
+// random returns a uniform random value in [1, m.inc), reading entropy
+// from m.Reader. When m.inc == 0 || m.inc == 1, it returns 1.
+// Adapted from: https://golang.org/pkg/crypto/rand/#Int
+func (m *MonotonicEntropy) random() (inc uint64, err error) {
+	if m.inc <= 1 {
+		return 1, nil
+	}
+
+	// Fast path for using a underlying rand.Rand directly.
+	if m.rng != nil {
+		// Range: [1, m.inc)
+		return 1 + uint64(m.rng.Int63n(int64(m.inc))), nil
+	}
+
+	// bitLen is the maximum bit length needed to encode a value < m.inc.
+	bitLen := bits.Len64(m.inc)
+
+	// byteLen is the maximum byte length needed to encode a value < m.inc.
+	byteLen := uint(bitLen+7) / 8
+
+	// msbitLen is the number of bits in the most significant byte of m.inc-1.
+	msbitLen := uint(bitLen % 8)
+	if msbitLen == 0 {
+		msbitLen = 8
+	}
+
+	for inc == 0 || inc >= m.inc {
+		if _, err = io.ReadFull(m.Reader, m.rand[:byteLen]); err != nil {
+			return 0, err
+		}
+
+		// Clear bits in the first byte to increase the probability
+		// that the candidate is < m.inc.
+		m.rand[0] &= uint8(int(1<<msbitLen) - 1)
+
+		// Convert the read bytes into an uint64 with byteLen
+		// Optimized unrolled loop.
+		switch byteLen {
+		case 1:
+			inc = uint64(m.rand[0])
+		case 2:
+			inc = uint64(binary.LittleEndian.Uint16(m.rand[:2]))
+		case 3, 4:
+			inc = uint64(binary.LittleEndian.Uint32(m.rand[:4]))
+		case 5, 6, 7, 8:
+			inc = uint64(binary.LittleEndian.Uint64(m.rand[:8]))
+		}
+	}
+
+	// Range: [1, m.inc)
+	return 1 + inc, nil
+}
+
+type uint80 struct {
+	Hi uint16
+	Lo uint64
+}
+
+func (u *uint80) SetBytes(bs []byte) {
+	u.Hi = binary.BigEndian.Uint16(bs[:2])
+	u.Lo = binary.BigEndian.Uint64(bs[2:])
+}
+
+func (u *uint80) AppendTo(bs []byte) {
+	binary.BigEndian.PutUint16(bs[:2], u.Hi)
+	binary.BigEndian.PutUint64(bs[2:], u.Lo)
+}
+
+func (u *uint80) Add(n uint64) (overflow bool) {
+	lo, hi := u.Lo, u.Hi
+	if u.Lo += n; u.Lo < lo {
+		u.Hi++
+	}
+	return u.Hi < hi
+}
+
+func (u uint80) IsZero() bool {
+	return u.Hi == 0 && u.Lo == 0
+}

--- a/examples/with_dependencies/plugins/ulid/vendor/github.com/slok/terraform-provider-goplugin/LICENSE
+++ b/examples/with_dependencies/plugins/ulid/vendor/github.com/slok/terraform-provider-goplugin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2022] [Xabier Larrakoetxea]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/with_dependencies/plugins/ulid/vendor/github.com/slok/terraform-provider-goplugin/pkg/api/v1/data_source.go
+++ b/examples/with_dependencies/plugins/ulid/vendor/github.com/slok/terraform-provider-goplugin/pkg/api/v1/data_source.go
@@ -1,0 +1,36 @@
+package v1
+
+import "context"
+
+// ReadDataSourceRequest is the request that the plugin will receive on resource `Read` operation.
+type ReadDataSourceRequest struct {
+	// Attributes is the data the Terraform user will provide to the plugin to manage the resource.
+	Attributes string
+}
+
+// ReadDataSourceResponse is the response that the plugin will return after resource `Read` operation.
+type ReadDataSourceResponse struct {
+	// Result is the result the plugin will return to Terraform.
+	Result string
+}
+
+// DataSourcePlugin knows how to handle a Terraform data source by implementing gathering data operations.
+type DataSourcePlugin interface {
+	// ReadDataSource will be responsible of:
+	//
+	// - Using the provided arguments to return a result.
+	ReadDataSource(ctx context.Context, r ReadDataSourceRequest) (*ReadDataSourceResponse, error)
+}
+
+// DefaultDataSourcePluginFactoryName is the default name used by the plugin engine to search for the plugin factory
+// on the plugin source code.
+const DefaultDataSourcePluginFactoryName = "NewDataSourcePlugin"
+
+// ResourcePluginFactory is the function type that the plugin engine will load and run to get the plugin that
+// will be executed afterwards. E.g:
+//
+//	func NewDataSourcePlugin(options string) (apiv1.DataSourcePlugin, error) {
+//		//...
+//		return myPlugin{}, nil
+//	}
+type DataSourcePluginFactory = func(options string) (DataSourcePlugin, error)

--- a/examples/with_dependencies/plugins/ulid/vendor/github.com/slok/terraform-provider-goplugin/pkg/api/v1/resource.go
+++ b/examples/with_dependencies/plugins/ulid/vendor/github.com/slok/terraform-provider-goplugin/pkg/api/v1/resource.go
@@ -1,0 +1,99 @@
+package v1
+
+import (
+	"context"
+)
+
+// CreateResourceRequest is the request that the plugin will receive on resource `Create` operation.
+type CreateResourceRequest struct {
+	// Attributes is the data the Terraform user will provide in the configuration (tf files) to the
+	// plugin to manage the resource.
+	Attributes string
+}
+
+// CreateResourceResponse is the response that the plugin will return after resource `Create` operation.
+type CreateResourceResponse struct {
+	// ID is the ID that tracks this resource.
+	ID string
+}
+
+// ReadResourceRequest is the request that the plugin will receive on resource `Read` operation.
+type ReadResourceRequest struct {
+	// ID is the ID that tracks this resource.
+	ID string
+}
+
+// ReadResourceResponse is the response that the plugin will return after resource `Read` operation.
+type ReadResourceResponse struct {
+	// Attributes is the data the Terraform user will provide in the configuration (tf files) to the
+	// plugin to manage the resource.
+	// On read operation normally this is used to refresh the state and check the attributes provided
+	// by the user match the ones that need to be read, then Terraform will watch for drifts.
+	Attributes string
+}
+
+// UpdateResourceRequest is the request that the plugin will receive on resource `Update` operation.
+type UpdateResourceRequest struct {
+	// ID is the ID that tracks this resource.
+	ID string
+	// Attributes is the data the Terraform user will provide in the configuration (tf files) to the
+	// plugin to manage the resource.
+	Attributes string
+	// AttributesState is the same as Attributes but instead of being the configuration from the user, are
+	// the attributes used on the previous terraform apply execution.
+	//
+	// This field is meant to be used used when we want to make decisions based on previous terraform apply changes.
+	// (E.g: A resource data attribute can't be changed after the creation, so if changes we return an error)
+	AttributesState string
+}
+
+// UpdateResourceResponse is the response that the plugin will return after resource `Update` operation.
+type UpdateResourceResponse struct{}
+
+// DeleteResourceRequest is the request that the plugin will receive on resource `Delete` operation.
+type DeleteResourceRequest struct {
+	// ID is the ID that tracks this resource.
+	ID string
+}
+
+// DeleteResourceResponse is the response that the plugin will return after resource `Delete` operation.
+type DeleteResourceResponse struct{}
+
+// ResourcePlugin knows how to handle a Terraform resource by implementing the common Terraform CRUD operations.
+type ResourcePlugin interface {
+	// CreateResource will be responsible of:
+	//
+	// - Creating the resource.
+	// - Returning the correct ID that will be used from now on to identify the resource.
+	// - Generating the ID with the required information to identify a resource (e.g aggregation of 2 properties as a single ID).
+	CreateResource(ctx context.Context, r CreateResourceRequest) (*CreateResourceResponse, error)
+
+	// ReadResource will be responsible of:
+	//
+	// - Using the ID for getting the current real data of the resource (Used on plans and imports).
+	ReadResource(ctx context.Context, r ReadResourceRequest) (*ReadResourceResponse, error)
+
+	// UpdateResource will be responsible of:
+	//
+	// - Using the resource data and ID update the resource if required.
+	// - Use the latest applied resource data (state data) to get diffs if required to patch/update specific parts.
+	UpdateResource(ctx context.Context, r UpdateResourceRequest) (*UpdateResourceResponse, error)
+
+	// DeleteResource will be responsible of:
+	//
+	// - Deleting the resource using the ID.
+	DeleteResource(ctx context.Context, r DeleteResourceRequest) (*DeleteResourceResponse, error)
+}
+
+// DefaultResourcePluginFactoryName is the default name used by the plugin engine to search for the plugin factory
+// on the plugin source code.
+const DefaultResourcePluginFactoryName = "NewResourcePlugin"
+
+// ResourcePluginFactory is the function type that the plugin engine will load and run to get the plugin that
+// will be executed afterwards. E.g:
+//
+//	func NewResourcePlugin(options string) (apiv1.ResourcePlugin, error) {
+//		//...
+//		return myPlugin{}, nil
+//	}
+type ResourcePluginFactory = func(options string) (ResourcePlugin, error)

--- a/examples/with_dependencies/plugins/ulid/vendor/modules.txt
+++ b/examples/with_dependencies/plugins/ulid/vendor/modules.txt
@@ -1,0 +1,6 @@
+# github.com/oklog/ulid/v2 v2.1.0
+## explicit; go 1.15
+github.com/oklog/ulid/v2
+# github.com/slok/terraform-provider-goplugin v0.4.0
+## explicit; go 1.19
+github.com/slok/terraform-provider-goplugin/pkg/api/v1

--- a/internal/plugin/storage/git/git_test.go
+++ b/internal/plugin/storage/git/git_test.go
@@ -2,20 +2,17 @@ package git_test
 
 import (
 	"context"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/slok/terraform-provider-goplugin/internal/plugin/storage/git"
 )
 
 func TestSourceCodeRepository(t *testing.T) {
 	tests := map[string]struct {
-		config  git.SourceCodeRepositoryConfig
-		expData []string
-		expErr  bool
+		config git.SourceCodeRepositoryConfig
+		expErr bool
 	}{
 		"Missing repository should fail.": {
 			config: git.SourceCodeRepositoryConfig{
@@ -24,19 +21,18 @@ func TestSourceCodeRepository(t *testing.T) {
 			expErr: true,
 		},
 
+		"Cloning a valid repo not being valid go package, should fail.": {
+			config: git.SourceCodeRepositoryConfig{
+				URL:         "https://github.com/slok/custom-css",
+				BranchOrTag: "main",
+			},
+			expErr: true,
+		},
+
 		"Cloning a repo by matching multiple files should return the data.": {
 			config: git.SourceCodeRepositoryConfig{
-				URL:         "https://github.com/slok/simple-ingress-external-auth",
-				BranchOrTag: "v0.3.0",
-				MatchRegexes: []*regexp.Regexp{
-					regexp.MustCompile(`^/scripts/[^/]*\.sh$`),
-					regexp.MustCompile(`^/\.github/CODEOWNERS$`),
-				},
-			},
-			expData: []string{
-				"*       @slok\n\n",
-				"#!/usr/bin/env sh\n\nset -o errexit\nset -o nounset\n\ngo mod tidy",
-				"#!/usr/bin/env sh\n\nset -o errexit\nset -o nounset\n\ngo generate ./...",
+				URL:         "https://github.com/oklog/run",
+				BranchOrTag: "v1.1.0",
 			},
 		},
 	}
@@ -44,16 +40,13 @@ func TestSourceCodeRepository(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			require := require.New(t)
 
 			repo, err := git.NewSourceCodeRepository(test.config)
 
 			if test.expErr {
 				assert.Error(err)
 			} else if assert.NoError(err) {
-				gotData, err := repo.GetSourceCode(context.TODO())
-				require.NoError(err)
-				assert.Equal(test.expData, gotData)
+				assert.NotNil(repo.FS(context.TODO()))
 			}
 		})
 	}

--- a/internal/plugin/storage/moduledir/moduledir.go
+++ b/internal/plugin/storage/moduledir/moduledir.go
@@ -1,0 +1,125 @@
+package moduledir
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"testing/fstest"
+
+	"github.com/slok/terraform-provider-goplugin/internal/plugin/storage"
+)
+
+type repo struct {
+	fs    fs.FS
+	pkg   string
+	index string
+}
+
+// NewSourceCodeRepository returns a SourceCodeRepository that will load the
+// root directory of a fs in a file system that is ready to be used by yaegi as
+// a go module loaded in the gopath.
+func NewSourceCodeRepository(dirFS fs.FS) (storage.SourceCodeRepository, error) {
+	r := repo{}
+
+	// TODO(slok): Cache.
+	err := r.init(dirFS)
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize repo: %w", err)
+	}
+
+	return r, nil
+}
+
+func (r repo) FS(ctx context.Context) fs.FS {
+	return r.fs
+}
+
+func (r repo) Index(ctx context.Context) string {
+	return r.index
+}
+
+func (r repo) Gopath(ctx context.Context) string {
+	return goPath
+}
+
+func (r repo) ImportPath(ctx context.Context) string {
+	return r.pkg
+}
+
+const (
+	goPath = "gopath"
+)
+
+func (r *repo) init(dirFS fs.FS) (err error) {
+	gomod, err := fs.ReadFile(dirFS, "go.mod")
+	if err != nil {
+		return fmt.Errorf("could not read go.mod: %w", err)
+	}
+
+	r.pkg, err = extractModule(string(gomod))
+	if err != nil {
+		return fmt.Errorf("could not extract module: %w", err)
+	}
+
+	srcRoot := fmt.Sprintf("%s/src/%s", goPath, r.pkg)
+
+	mapFS := map[string]*fstest.MapFile{}
+	tmpData := ""
+	err = fs.WalkDir(dirFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		// Ignore unwanted files.
+		for _, rx := range filesToIgnore {
+			if rx.MatchString(path) {
+				return nil
+			}
+		}
+
+		fileData, err := fs.ReadFile(dirFS, path)
+		if err != nil {
+			return fmt.Errorf("could not read  %s: %w", path, err)
+		}
+
+		fileName := fmt.Sprintf("%s/%s", srcRoot, path)
+
+		// Append data file.
+		mapFS[fileName] = &fstest.MapFile{Data: fileData}
+		tmpData += string(fileData)
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("could not walk directory: %w", err)
+	}
+
+	r.fs = fstest.MapFS(mapFS)
+	r.index = fmt.Sprintf("%x", sha256.Sum256([]byte(tmpData)))
+
+	return nil
+}
+
+var filesToIgnore = []*regexp.Regexp{
+	regexp.MustCompile("vendor/github.com/slok/terraform-provider-goplugin/.*$"),
+	regexp.MustCompile("vendor/github.com/traefik/yaegi/.*$"),
+	regexp.MustCompile("^.git/.*$"),
+}
+
+var moduleRegexp = regexp.MustCompile(`(?m)^module +([^\s]+) *$`)
+
+func extractModule(gomod string) (string, error) {
+	// Discover module name.
+	moduleMatch := moduleRegexp.FindStringSubmatch(gomod)
+	if len(moduleMatch) != 2 {
+		return "", fmt.Errorf("invalid go module, could not get module name")
+	}
+
+	return moduleMatch[1], nil
+}

--- a/internal/plugin/storage/moduledir/moduledir_test.go
+++ b/internal/plugin/storage/moduledir/moduledir_test.go
@@ -1,0 +1,77 @@
+package moduledir_test
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/slok/terraform-provider-goplugin/internal/plugin/storage/moduledir"
+)
+
+func TestSourceCodeRepository(t *testing.T) {
+	tests := map[string]struct {
+		dir          string
+		expDataFiles map[string]string
+		expErr       bool
+	}{
+		"An invalid Go package should fail.": {
+			dir:    "testdata/pkg2",
+			expErr: true,
+		},
+
+		"Loading a valid package should load the package.": {
+			dir: "testdata/pkg1",
+			expDataFiles: map[string]string{
+				"gopath/src/pkg1/go.mod":         "module pkg1\n",
+				"gopath/src/pkg1/test1/f1.go":    "package test1\n\nfunc test1() {}\n",
+				"gopath/src/pkg1/test2/test2.go": "package test2\n\nfunc test2() {}\n",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			repo, err := moduledir.NewSourceCodeRepository(os.DirFS(test.dir))
+
+			if test.expErr {
+				assert.Error(err)
+			} else if assert.NoError(err) {
+				gotDataFiles := getFSFiles(repo.FS(context.TODO()))
+				assert.Equal(test.expDataFiles, gotDataFiles)
+
+			}
+		})
+	}
+}
+
+func getFSFiles(f fs.FS) map[string]string {
+	data := map[string]string{}
+	err := fs.WalkDir(f, ".", fs.WalkDirFunc(func(path string, info fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		bs, err := fs.ReadFile(f, path)
+		if err != nil {
+			return err
+		}
+
+		data[path] = string(bs)
+
+		return nil
+	}))
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}

--- a/internal/plugin/storage/moduledir/testdata/pkg1/go.mod
+++ b/internal/plugin/storage/moduledir/testdata/pkg1/go.mod
@@ -1,0 +1,1 @@
+module pkg1

--- a/internal/plugin/storage/moduledir/testdata/pkg1/test1/f1.go
+++ b/internal/plugin/storage/moduledir/testdata/pkg1/test1/f1.go
@@ -1,0 +1,3 @@
+package test1
+
+func test1() {}

--- a/internal/plugin/storage/moduledir/testdata/pkg1/test2/test2.go
+++ b/internal/plugin/storage/moduledir/testdata/pkg1/test2/test2.go
@@ -1,0 +1,3 @@
+package test2
+
+func test2() {}

--- a/internal/plugin/storage/moduledir/testdata/pkg2/test1/f1.go
+++ b/internal/plugin/storage/moduledir/testdata/pkg2/test1/f1.go
@@ -1,0 +1,3 @@
+package test1
+
+func test1() {}

--- a/internal/plugin/storage/storage.go
+++ b/internal/plugin/storage/storage.go
@@ -1,14 +1,13 @@
 package storage
 
-import "context"
+import (
+	"context"
+	"io/fs"
+)
 
 type SourceCodeRepository interface {
-	GetSourceCode(ctx context.Context) ([]string, error)
-}
-
-// StaticSourceCodeRepository will be used to make a []string behave like a source code repository.
-type StaticSourceCodeRepository []string
-
-func (s StaticSourceCodeRepository) GetSourceCode(ctx context.Context) ([]string, error) {
-	return s, nil
+	FS(ctx context.Context) fs.FS
+	Index(ctx context.Context) string
+	Gopath(ctx context.Context) string
+	ImportPath(ctx context.Context) string
 }

--- a/internal/plugin/v1/testdata/plugin_error/go.mod
+++ b/internal/plugin/v1/testdata/plugin_error/go.mod
@@ -1,0 +1,1 @@
+module test

--- a/internal/plugin/v1/testdata/plugin_noop/go.mod
+++ b/internal/plugin/v1/testdata/plugin_noop/go.mod
@@ -1,0 +1,1 @@
+module test

--- a/internal/plugin/v1/testdata/plugin_ok/go.mod
+++ b/internal/plugin/v1/testdata/plugin_ok/go.mod
@@ -1,0 +1,1 @@
+module test

--- a/internal/provider/data_source_plugin_v1_test.go
+++ b/internal/provider/data_source_plugin_v1_test.go
@@ -21,7 +21,7 @@ provider goplugin {
   data_source_plugins_v1 = {
     "fake": {
       source_code = {
-		data = [file("testdata/fake_data_source/plugin.go")]
+		dir = "testdata/fake_data_source"
 	  }
       configuration =  jsonencode({})
     }

--- a/internal/provider/resource_plugin_v1_test.go
+++ b/internal/provider/resource_plugin_v1_test.go
@@ -25,7 +25,7 @@ provider goplugin {
   resource_plugins_v1 = {
     "test_file": {
       source_code = {
-		data = [file("testdata/file_plugin/plugin.go")]
+		dir = "testdata/file_plugin"
 	  }
       configuration =  jsonencode({})
     }

--- a/internal/provider/testdata/fake_data_source/go.mod
+++ b/internal/provider/testdata/fake_data_source/go.mod
@@ -1,0 +1,1 @@
+module plugin

--- a/internal/provider/testdata/file_plugin/go.mod
+++ b/internal/provider/testdata/file_plugin/go.mod
@@ -1,0 +1,1 @@
+module plugin


### PR DESCRIPTION
This PR changes how the source code is loaded. Allowing pluigns using 3rth party dependencies using `vendor` packge.

Mainly it does 2 things:
- Removes the ability to load single files.
- Forces loading Go modules (root with a `go.mod`).

This has multiple benefits like a Single way of loading go source code, and the most important one: allowing loading plugins with dependencies using `vendor` package.